### PR TITLE
OMAF extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+
 *.o
 *.d
 *.suo

--- a/IsoLib/hevc_extractors/w32/hevc_extractors.sln
+++ b/IsoLib/hevc_extractors/w32/hevc_extractors.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.21005.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "hevc_extractors", "hevc_extractors.vcxproj", "{08081428-086D-4928-9FED-60D786C2888F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{08081428-086D-4928-9FED-60D786C2888F}.Debug|Win32.ActiveCfg = Debug|Win32
+		{08081428-086D-4928-9FED-60D786C2888F}.Debug|Win32.Build.0 = Debug|Win32
+		{08081428-086D-4928-9FED-60D786C2888F}.Release|Win32.ActiveCfg = Release|Win32
+		{08081428-086D-4928-9FED-60D786C2888F}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/IsoLib/hevc_extractors/w32/hevc_extractors.vcxproj
+++ b/IsoLib/hevc_extractors/w32/hevc_extractors.vcxproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{08081428-086D-4928-9FED-60D786C2888F}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>hevc_extractors</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <LibraryPath>..\..\libisomediafile\w32\libisomediafile\Debug;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../libisomediafile\w32;../../libisomediafile\src</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>libisomedia.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\HEVCExtractorReader.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\HEVCExtractorReader.cpp" />
+    <ClCompile Include="..\src\hevc_extractors.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/IsoLib/hevc_extractors/w32/hevc_extractors.vcxproj.filters
+++ b/IsoLib/hevc_extractors/w32/hevc_extractors.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\HEVCExtractorReader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\hevc_extractors.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\HEVCExtractorReader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/IsoLib/libisomediafile/linux/libisomediafile/Makefile
+++ b/IsoLib/libisomediafile/linux/libisomediafile/Makefile
@@ -165,6 +165,7 @@ sources = \
 	CompatibleSchemeTypeAtom.c \
 	RestrictedSchemeInfoAtom.c \
 	StereoVideoAtom.c \
+	StereoVideoGroupAtom.c \
 	TrackTypeAtom.c \
 	RestrictedVideoSampleEntry.c
 	

--- a/IsoLib/libisomediafile/linux/libisomediafile/Makefile
+++ b/IsoLib/libisomediafile/linux/libisomediafile/Makefile
@@ -160,8 +160,14 @@ sources = \
 	SingleItemTypeReferenceAtom.c \
 	ItemPropertiesAtom.c \
 	ItemPropertyAssociationAtom.c \
-	ItemPropertyContainerAtom.c
-
+	ItemPropertyContainerAtom.c \
+	SchemeTypeAtom.c \
+	CompatibleSchemeTypeAtom.c \
+	RestrictedSchemeInfoAtom.c \
+	StereoVideoAtom.c \
+	TrackTypeAtom.c \
+	RestrictedVideoSampleEntry.c
+	
 
 
 

--- a/IsoLib/libisomediafile/macosx/libisomediafile/Makefile
+++ b/IsoLib/libisomediafile/macosx/libisomediafile/Makefile
@@ -160,7 +160,13 @@ sources = \
 	SingleItemTypeReferenceAtom.c \
 	ItemPropertiesAtom.c \
 	ItemPropertyAssociationAtom.c \
-	ItemPropertyContainerAtom.c
+	ItemPropertyContainerAtom.c \
+	SchemeTypeAtom.c \
+	CompatibleSchemeTypeAtom.c \
+	RestrictedSchemeInfoAtom.c \
+	StereoVideoAtom.c \
+	TrackTypeAtom.c \
+	RestrictedVideoSampleEntry.c
 
 
 

--- a/IsoLib/libisomediafile/macosx/libisomediafile/libisomediafile.xcodeproj/project.pbxproj
+++ b/IsoLib/libisomediafile/macosx/libisomediafile/libisomediafile.xcodeproj/project.pbxproj
@@ -21,6 +21,12 @@
 		18CF72071A0D9419006648A8 /* ItemReferenceAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 18CF72061A0D9419006648A8 /* ItemReferenceAtom.c */; };
 		18CF72091A0D966E006648A8 /* SingleItemTypeReferenceAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 18CF72081A0D966E006648A8 /* SingleItemTypeReferenceAtom.c */; };
 		18CF720B1A12C7E2006648A8 /* ItemDataAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 18CF720A1A12C7E2006648A8 /* ItemDataAtom.c */; };
+		3A25425820317010001A7B60 /* CompatibleSchemeTypeAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A25425220317010001A7B60 /* CompatibleSchemeTypeAtom.c */; };
+		3A25425920317010001A7B60 /* RestrictedSchemeInfoAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A25425320317010001A7B60 /* RestrictedSchemeInfoAtom.c */; };
+		3A25425A20317010001A7B60 /* RestrictedVideoSampleEntry.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A25425420317010001A7B60 /* RestrictedVideoSampleEntry.c */; };
+		3A25425B20317010001A7B60 /* SchemeTypeAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A25425520317010001A7B60 /* SchemeTypeAtom.c */; };
+		3A25425C20317010001A7B60 /* StereoVideoAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A25425620317010001A7B60 /* StereoVideoAtom.c */; };
+		3A25425D20317010001A7B60 /* TrackTypeAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A25425720317010001A7B60 /* TrackTypeAtom.c */; };
 		B4A11E5C1B1FB11E002C5FD1 /* HEVCConfigAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = B4A11E5B1B1FB11B002C5FD1 /* HEVCConfigAtom.c */; };
 		B4A11E5E1B1FB163002C5FD1 /* SubSampleInformationAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = B4A11E5D1B1FB160002C5FD1 /* SubSampleInformationAtom.c */; };
 		B4A11E601B1FB19D002C5FD1 /* TrackGroupAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = B4A11E5F1B1FB19A002C5FD1 /* TrackGroupAtom.c */; };
@@ -194,6 +200,12 @@
 		18CF72061A0D9419006648A8 /* ItemReferenceAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ItemReferenceAtom.c; path = ../../src/ItemReferenceAtom.c; sourceTree = "<group>"; };
 		18CF72081A0D966E006648A8 /* SingleItemTypeReferenceAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SingleItemTypeReferenceAtom.c; path = ../../src/SingleItemTypeReferenceAtom.c; sourceTree = "<group>"; };
 		18CF720A1A12C7E2006648A8 /* ItemDataAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ItemDataAtom.c; path = ../../src/ItemDataAtom.c; sourceTree = "<group>"; };
+		3A25425220317010001A7B60 /* CompatibleSchemeTypeAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = CompatibleSchemeTypeAtom.c; path = ../../src/CompatibleSchemeTypeAtom.c; sourceTree = "<group>"; };
+		3A25425320317010001A7B60 /* RestrictedSchemeInfoAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = RestrictedSchemeInfoAtom.c; path = ../../src/RestrictedSchemeInfoAtom.c; sourceTree = "<group>"; };
+		3A25425420317010001A7B60 /* RestrictedVideoSampleEntry.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = RestrictedVideoSampleEntry.c; path = ../../src/RestrictedVideoSampleEntry.c; sourceTree = "<group>"; };
+		3A25425520317010001A7B60 /* SchemeTypeAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SchemeTypeAtom.c; path = ../../src/SchemeTypeAtom.c; sourceTree = "<group>"; };
+		3A25425620317010001A7B60 /* StereoVideoAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = StereoVideoAtom.c; path = ../../src/StereoVideoAtom.c; sourceTree = "<group>"; };
+		3A25425720317010001A7B60 /* TrackTypeAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = TrackTypeAtom.c; path = ../../src/TrackTypeAtom.c; sourceTree = "<group>"; };
 		B4A11E5B1B1FB11B002C5FD1 /* HEVCConfigAtom.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = HEVCConfigAtom.c; path = ../../src/HEVCConfigAtom.c; sourceTree = "<group>"; };
 		B4A11E5D1B1FB160002C5FD1 /* SubSampleInformationAtom.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = SubSampleInformationAtom.c; path = ../../src/SubSampleInformationAtom.c; sourceTree = "<group>"; };
 		B4A11E5F1B1FB19A002C5FD1 /* TrackGroupAtom.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = TrackGroupAtom.c; path = ../../src/TrackGroupAtom.c; sourceTree = "<group>"; };
@@ -451,6 +463,12 @@
 				CBAD4E8907B2B3F8005AD21E /* MovieAtom.c */,
 				CBAD4E8807B2B3F8005AD21E /* MovieExtendsAtom.c */,
 				189725A919F82063001D1219 /* TrackExtensionPropertiesAtom.c */,
+				3A25425220317010001A7B60 /* CompatibleSchemeTypeAtom.c */,
+				3A25425320317010001A7B60 /* RestrictedSchemeInfoAtom.c */,
+				3A25425420317010001A7B60 /* RestrictedVideoSampleEntry.c */,
+				3A25425520317010001A7B60 /* SchemeTypeAtom.c */,
+				3A25425620317010001A7B60 /* StereoVideoAtom.c */,
+				3A25425720317010001A7B60 /* TrackTypeAtom.c */,
 				CBAD4E8707B2B3F8005AD21E /* MovieFragmentAtom.c */,
 				CBAD4E8607B2B3F8005AD21E /* MovieFragmentHeaderAtom.c */,
 				CBAD4E8507B2B3F8005AD21E /* MovieHeaderAtom.c */,
@@ -646,6 +664,7 @@
 				CBAD4EA207B2B3F8005AD21E /* DataReferenceAtom.c in Sources */,
 				CBAD4EA307B2B3F8005AD21E /* DataInformationAtom.c in Sources */,
 				CBAD4EA407B2B3F8005AD21E /* DataEntryURNAtom.c in Sources */,
+				3A25425A20317010001A7B60 /* RestrictedVideoSampleEntry.c in Sources */,
 				CBAD4EA507B2B3F8005AD21E /* VideoMediaHeaderAtom.c in Sources */,
 				CBAD4EA607B2B3F8005AD21E /* UserDataAtom.c in Sources */,
 				CBAD4EA707B2B3F8005AD21E /* UnknownAtom.c in Sources */,
@@ -666,6 +685,7 @@
 				CBAD4EB207B2B3F8005AD21E /* GenericSampleEntryAtom.c in Sources */,
 				CBAD4EB307B2B3F8005AD21E /* FreeSpaceAtom.c in Sources */,
 				CBAD4EB507B2B3F8005AD21E /* MP4InitialObjectDescriptor.c in Sources */,
+				3A25425D20317010001A7B60 /* TrackTypeAtom.c in Sources */,
 				188041DD19CBA54300FAABCE /* DownMixInstructionsAtom.c in Sources */,
 				CBAD4EB707B2B3F8005AD21E /* IPMPToolUpdateCommand.c in Sources */,
 				CBAD4EB807B2B3F8005AD21E /* HintMediaHeaderAtom.c in Sources */,
@@ -676,6 +696,7 @@
 				CBAD4EBD07B2B3F8005AD21E /* MP4MemoryInputStream.c in Sources */,
 				CBAD4EBE07B2B3F8005AD21E /* MP4Media.c in Sources */,
 				188041E119CCA28A00FAABCE /* LoudnessAtom.c in Sources */,
+				3A25425820317010001A7B60 /* CompatibleSchemeTypeAtom.c in Sources */,
 				CBAD4EBF07B2B3F8005AD21E /* SceneDescriptionMediaHeader.c in Sources */,
 				CBAD4EC007B2B3F8005AD21E /* SampleToChunkAtom.c in Sources */,
 				CBAD4EC107B2B3F8005AD21E /* SampleTableAtom.c in Sources */,
@@ -695,6 +716,7 @@
 				CBAD4ED007B2B3F8005AD21E /* ESDAtom.c in Sources */,
 				CBAD4ED107B2B3F8005AD21E /* EncVisualSampleEntryAtom.c in Sources */,
 				CBAD4ED207B2B3F8005AD21E /* TrackFragmentAtom.c in Sources */,
+				3A25425920317010001A7B60 /* RestrictedSchemeInfoAtom.c in Sources */,
 				CBAD4ED307B2B3F8005AD21E /* TrackExtendsAtom.c in Sources */,
 				CBAD4ED407B2B3F8005AD21E /* TrackAtom.c in Sources */,
 				CBAD4ED507B2B3F8005AD21E /* SecuritySchemeAtom.c in Sources */,
@@ -710,6 +732,7 @@
 				CBAD4EE107B2B3F8005AD21E /* MP4LinkedList.c in Sources */,
 				CBAD4EE207B2B3F8005AD21E /* MP4IPMPXDefaultData.c in Sources */,
 				CBAD4EE407B2B3F8005AD21E /* MP4IPMPXData.c in Sources */,
+				3A25425C20317010001A7B60 /* StereoVideoAtom.c in Sources */,
 				CBAD4EE507B2B3F8005AD21E /* SoundMediaHeaderAtom.c in Sources */,
 				CBAD4EE607B2B3F8005AD21E /* SLConfigDescriptor.c in Sources */,
 				CBAD4EE707B2B3F8005AD21E /* ShadowSyncAtom.c in Sources */,
@@ -785,6 +808,7 @@
 				CB9CF8290AD57A4200F8F722 /* ISOSampleDescriptions.c in Sources */,
 				C6F5636219ABE6BB0010D96F /* TrackFragmentDecodeTimeAtom.c in Sources */,
 				CB9CF8350AD57AEC00F8F722 /* VCConfigAtom.c in Sources */,
+				3A25425B20317010001A7B60 /* SchemeTypeAtom.c in Sources */,
 				B4A11E5C1B1FB11E002C5FD1 /* HEVCConfigAtom.c in Sources */,
 				CBF7AFDD0AEDE9CA0027965D /* XMLMetaSampleEntry.c in Sources */,
 				189725AC19F966C6001D1219 /* SampleAuxiliaryInformationSizesAtom.c in Sources */,

--- a/IsoLib/libisomediafile/macosx/libisomediafile/libisomediafile.xcodeproj/project.pbxproj
+++ b/IsoLib/libisomediafile/macosx/libisomediafile/libisomediafile.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		3A25425B20317010001A7B60 /* SchemeTypeAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A25425520317010001A7B60 /* SchemeTypeAtom.c */; };
 		3A25425C20317010001A7B60 /* StereoVideoAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A25425620317010001A7B60 /* StereoVideoAtom.c */; };
 		3A25425D20317010001A7B60 /* TrackTypeAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A25425720317010001A7B60 /* TrackTypeAtom.c */; };
+		3AE6A1A420522FA300032735 /* StereoVideoGroupAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = 3AE6A1A320522FA300032735 /* StereoVideoGroupAtom.c */; };
 		B4A11E5C1B1FB11E002C5FD1 /* HEVCConfigAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = B4A11E5B1B1FB11B002C5FD1 /* HEVCConfigAtom.c */; };
 		B4A11E5E1B1FB163002C5FD1 /* SubSampleInformationAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = B4A11E5D1B1FB160002C5FD1 /* SubSampleInformationAtom.c */; };
 		B4A11E601B1FB19D002C5FD1 /* TrackGroupAtom.c in Sources */ = {isa = PBXBuildFile; fileRef = B4A11E5F1B1FB19A002C5FD1 /* TrackGroupAtom.c */; };
@@ -206,6 +207,7 @@
 		3A25425520317010001A7B60 /* SchemeTypeAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SchemeTypeAtom.c; path = ../../src/SchemeTypeAtom.c; sourceTree = "<group>"; };
 		3A25425620317010001A7B60 /* StereoVideoAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = StereoVideoAtom.c; path = ../../src/StereoVideoAtom.c; sourceTree = "<group>"; };
 		3A25425720317010001A7B60 /* TrackTypeAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = TrackTypeAtom.c; path = ../../src/TrackTypeAtom.c; sourceTree = "<group>"; };
+		3AE6A1A320522FA300032735 /* StereoVideoGroupAtom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = StereoVideoGroupAtom.c; path = ../../src/StereoVideoGroupAtom.c; sourceTree = "<group>"; };
 		B4A11E5B1B1FB11B002C5FD1 /* HEVCConfigAtom.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = HEVCConfigAtom.c; path = ../../src/HEVCConfigAtom.c; sourceTree = "<group>"; };
 		B4A11E5D1B1FB160002C5FD1 /* SubSampleInformationAtom.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = SubSampleInformationAtom.c; path = ../../src/SubSampleInformationAtom.c; sourceTree = "<group>"; };
 		B4A11E5F1B1FB19A002C5FD1 /* TrackGroupAtom.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = TrackGroupAtom.c; path = ../../src/TrackGroupAtom.c; sourceTree = "<group>"; };
@@ -389,6 +391,7 @@
 		08FB7795FE84155DC02AAC07 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				3AE6A1A320522FA300032735 /* StereoVideoGroupAtom.c */,
 				C6D4549E1DB513B3001B936A /* ItemPropertiesAtom.c */,
 				C6D4549F1DB513B3001B936A /* ItemPropertyAssociationAtom.c */,
 				C6D454A01DB513B3001B936A /* ItemPropertyContainerAtom.c */,
@@ -705,6 +708,7 @@
 				CBAD4EC407B2B3F8005AD21E /* QTMovies.c in Sources */,
 				CBAD4EC507B2B3F8005AD21E /* PaddingBitsAtom.c in Sources */,
 				CBAD4EC607B2B3F8005AD21E /* MediaHeaderAtom.c in Sources */,
+				3AE6A1A420522FA300032735 /* StereoVideoGroupAtom.c in Sources */,
 				C6D454A11DB513B3001B936A /* ItemPropertiesAtom.c in Sources */,
 				CBAD4EC707B2B3F8005AD21E /* MediaDataAtom.c in Sources */,
 				CBAD4EC807B2B3F8005AD21E /* MediaAtom.c in Sources */,

--- a/IsoLib/libisomediafile/src/CompatibleSchemeTypeAtom.c
+++ b/IsoLib/libisomediafile/src/CompatibleSchemeTypeAtom.c
@@ -1,3 +1,36 @@
+/*
+ * This software module was originally developed by InterDigital, Inc.
+ * in the course of development of MPEG-4.
+ * This software module is an implementation of a part of one or
+ * more MPEG-4 tools as specified by MPEG-4.
+ * ISO/IEC gives users of MPEG-4 free license to this
+ * software module or modifications thereof for use in hardware
+ * or software products claiming conformance to MPEG-4 only for evaluation and testing purposes.
+ * Those intending to use this software module in hardware or software
+ * products are advised that its use may infringe existing patents.
+ * The original developer of this software module and his/her company,
+ * the subsequent editors and their companies, and ISO/IEC have no
+ * liability for use of this software module or modifications thereof
+ * in an implementation.
+ *
+ * Copyright is not released for non MPEG-4 conforming
+ * products. InterDigital, Inc. retains full right to use the code for its own
+ * purpose, assign or donate the code to a third party and to
+ * inhibit third parties from using the code for non
+ * MPEG-4 conforming products.
+ *
+ * This copyright notice must be included in all copies or
+ * derivative works.
+ */
+
+
+/**
+* @file CompatibleSchemeTypeAtom.c
+* @author Ahmed Hamza <Ahmed.Hamza@InterDigital.com>
+* @date
+* @brief Implements functions for reading and writing CompatibleSchemeTypeAtom instances.
+*/
+
 
 #include "MP4Atoms.h"
 #include <stdlib.h>
@@ -132,8 +165,8 @@ MP4Err MP4CreateCompatibleSchemeTypeAtom(MP4CompatibleSchemeTypeAtomPtr *outAtom
 	self = (MP4CompatibleSchemeTypeAtomPtr)calloc(1, sizeof(MP4CompatibleSchemeTypeAtom));
 	TESTMALLOC(self);
 
-	err = MP4CreateFullAtom((MP4AtomPtr)self);
-	if (err) goto bail;
+	err = MP4CreateFullAtom((MP4AtomPtr)self); if (err) goto bail;
+
 	self->type = MP4SchemeTypeAtomType;
 	self->name = "CompatibleSchemeTypeBox";
 	self->createFromInputStream = (cisfunc)createFromInputStream;

--- a/IsoLib/libisomediafile/src/CompatibleSchemeTypeAtom.c
+++ b/IsoLib/libisomediafile/src/CompatibleSchemeTypeAtom.c
@@ -3,14 +3,145 @@
 #include <stdlib.h>
 #include <string.h>
 
-// TODO Complete
 
+
+static void destroy(MP4AtomPtr s)
+{
+	MP4Err err;
+	MP4CompatibleSchemeTypeAtomPtr self = (MP4CompatibleSchemeTypeAtomPtr)s;
+	err = MP4NoErr;
+
+	if (self == NULL)
+		BAILWITHERROR(MP4BadParamErr);
+
+	// if there is a scheme_url field, free it
+	if (self->scheme_url) {
+		free(self->scheme_url);
+		self->scheme_url = NULL;
+	}
+
+	if (self->super)
+		self->super->destroy(s);
+bail:
+	TEST_RETURN(err);
+
+	return;
+}
+
+
+static MP4Err serialize(struct MP4Atom* s, char* buffer)
+{
+	MP4Err err;
+	MP4CompatibleSchemeTypeAtomPtr self = (MP4CompatibleSchemeTypeAtomPtr)s;
+	err = MP4NoErr;
+
+	err = MP4SerializeCommonFullAtomFields((MP4FullAtomPtr)s, buffer); if (err) goto bail;
+	buffer += self->bytesWritten;
+	
+	PUT32(scheme_type);
+	PUT32(scheme_version);
+	if ((self->flags & 1) == 1)
+	{
+		u32 len = strlen(self->scheme_url) + 1;
+		PUTBYTES(self->scheme_url, len);
+	}
+
+	assert(self->bytesWritten == self->size);
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err calculateSize(struct MP4Atom* s)
+{
+	MP4Err err;
+	MP4CompatibleSchemeTypeAtomPtr self = (MP4CompatibleSchemeTypeAtomPtr)s;
+	err = MP4NoErr;
+
+	err = MP4CalculateFullAtomFieldSize((MP4FullAtomPtr)s); if (err) goto bail;
+	self->size += 8;  // 4 bytes (scheme_type) + 4 bytes (scheme_version)
+	if ((self->scheme_url) && (strlen(self->scheme_url) > 0))
+	{
+		self->flags = 1;
+		self->size += 1 + strlen(self->scheme_url); // strlen ignores \0
+	}
+	else self->flags = 0;
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+
+static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStreamPtr inputStream)
+{
+	MP4Err err;
+	long bytesToRead;
+	char debugstr[256];
+	MP4CompatibleSchemeTypeAtomPtr self = (MP4CompatibleSchemeTypeAtomPtr)s;
+
+	err = MP4NoErr;
+	if (self == NULL)	
+		BAILWITHERROR(MP4BadParamErr);
+		
+	err = self->super->createFromInputStream(s, proto, (char*)inputStream); if (err) goto bail;
+	
+	GET32(scheme_type);
+	GET32(scheme_version);
+	
+	bytesToRead = self->size - self->bytesRead;
+	if (bytesToRead < 0)
+		BAILWITHERROR(MP4BadDataErr);
+
+	if (bytesToRead > 0)
+	{
+		if ((self->flags & 1) != 1) { err = MP4BadDataErr; goto bail; }
+		self->scheme_url = (char*)calloc(1, bytesToRead);
+		if (self->scheme_url == NULL)
+			BAILWITHERROR(MP4NoMemoryErr);
+			
+		GETBYTES(bytesToRead, scheme_url);
+		
+		if (bytesToRead < 200)
+		{
+			sprintf(debugstr, "Scheme URL location is \"%s\"", self->scheme_url);
+			DEBUG_MSG(debugstr);
+		}
+	}
+	else
+	{
+		if ((self->flags & 1) != 0) { err = MP4BadDataErr; goto bail; }
+	}
+
+	assert(self->bytesRead == self->size);
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
 
 
 MP4Err MP4CreateCompatibleSchemeTypeAtom(MP4CompatibleSchemeTypeAtomPtr *outAtom) {
 
 	MP4Err err;
 	MP4CompatibleSchemeTypeAtomPtr self;
+
+	self = (MP4CompatibleSchemeTypeAtomPtr)calloc(1, sizeof(MP4CompatibleSchemeTypeAtom));
+	TESTMALLOC(self);
+
+	err = MP4CreateFullAtom((MP4AtomPtr)self);
+	if (err) goto bail;
+	self->type = MP4SchemeTypeAtomType;
+	self->name = "CompatibleSchemeTypeBox";
+	self->createFromInputStream = (cisfunc)createFromInputStream;
+	self->destroy = destroy;
+	self->calculateSize = calculateSize;
+	self->serialize = serialize;
+
+	*outAtom = self;
 
 bail:
 	TEST_RETURN(err);

--- a/IsoLib/libisomediafile/src/CompatibleSchemeTypeAtom.c
+++ b/IsoLib/libisomediafile/src/CompatibleSchemeTypeAtom.c
@@ -47,7 +47,7 @@ static void destroy(MP4AtomPtr s)
 	if (self == NULL)
 		BAILWITHERROR(MP4BadParamErr);
 
-	// if there is a scheme_url field, free it
+	/* if there is a scheme_url field, free it */
 	if (self->scheme_url) {
 		free(self->scheme_url);
 		self->scheme_url = NULL;
@@ -93,11 +93,11 @@ static MP4Err calculateSize(struct MP4Atom* s)
 	err = MP4NoErr;
 
 	err = MP4CalculateFullAtomFieldSize((MP4FullAtomPtr)s); if (err) goto bail;
-	self->size += 8;  // 4 bytes (scheme_type) + 4 bytes (scheme_version)
+	self->size += 8;  /* 4 bytes (scheme_type) + 4 bytes (scheme_version) */
 	if ((self->scheme_url) && (strlen(self->scheme_url) > 0))
 	{
 		self->flags = 1;
-		self->size += 1 + strlen(self->scheme_url); // strlen ignores \0
+		self->size += 1 + strlen(self->scheme_url); /* strlen ignores \0 */
 	}
 	else self->flags = 0;
 

--- a/IsoLib/libisomediafile/src/CompatibleSchemeTypeAtom.c
+++ b/IsoLib/libisomediafile/src/CompatibleSchemeTypeAtom.c
@@ -1,0 +1,20 @@
+
+#include "MP4Atoms.h"
+#include <stdlib.h>
+#include <string.h>
+
+// TODO Complete
+
+
+
+MP4Err MP4CreateCompatibleSchemeTypeAtom(MP4CompatibleSchemeTypeAtomPtr *outAtom) {
+
+	MP4Err err;
+	MP4CompatibleSchemeTypeAtomPtr self;
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+

--- a/IsoLib/libisomediafile/src/EncAudioSampleEntryAtom.c
+++ b/IsoLib/libisomediafile/src/EncAudioSampleEntryAtom.c
@@ -162,7 +162,7 @@ static MP4Err transform(struct MP4Atom *s, u32 sch_type, u32 sch_version, char* 
 
 	err = MP4CreateSchemeInfoAtom( &schi ); if (err) goto bail;
 	
-	err = MP4CreateSecuritySchemeAtom( &schm ); if (err) goto bail;
+	err = MP4CreateSchemeTypeAtom( &schm ); if (err) goto bail;
 	schm->scheme_type    = sch_type;
 	schm->scheme_version = sch_version;
 	

--- a/IsoLib/libisomediafile/src/EncAudioSampleEntryAtom.c
+++ b/IsoLib/libisomediafile/src/EncAudioSampleEntryAtom.c
@@ -153,7 +153,7 @@ static MP4Err transform(struct MP4Atom *s, u32 sch_type, u32 sch_version, char* 
 	MP4EncBaseSampleEntryAtomPtr self = (MP4EncBaseSampleEntryAtomPtr) s;
 	MP4OriginalFormatAtomPtr fmt;
 	MP4SecurityInfoAtomPtr sinf;
-	MP4SecuritySchemeAtomPtr schm;
+	MP4SchemeTypeAtomPtr schm;
 	MP4SchemeInfoAtomPtr schi;
 	char* sch_url_copy = NULL;
 	
@@ -176,7 +176,7 @@ static MP4Err transform(struct MP4Atom *s, u32 sch_type, u32 sch_version, char* 
 
 	err = MP4CreateSecurityInfoAtom( &sinf ); if (err) goto bail;
 	sinf->MP4OriginalFormat = (MP4AtomPtr) fmt; fmt = NULL;
-	sinf->MP4SecurityScheme = (MP4AtomPtr) schm; schm = NULL;
+	sinf->MP4SchemeType = (MP4AtomPtr) schm; schm = NULL;
 	sinf->MP4SchemeInfo     = (MP4AtomPtr) schi; schi = NULL;
 	
 	self->type = self->enc_type;
@@ -290,7 +290,7 @@ static MP4Err getScheme(struct MP4Atom *s, u32* sch_type, u32* sch_version, char
 	MP4Err err;
 	
 	MP4EncBaseSampleEntryAtomPtr self = (MP4EncBaseSampleEntryAtomPtr) s;
-	MP4SecuritySchemeAtomPtr  schm;
+	MP4SchemeTypeAtomPtr  schm;
 	MP4SecurityInfoAtomPtr sinf;
 	char* sch_url_copy;
 
@@ -299,7 +299,7 @@ static MP4Err getScheme(struct MP4Atom *s, u32* sch_type, u32* sch_version, char
 	sinf = (MP4SecurityInfoAtomPtr) self->SecurityInfo;
 	if (!sinf) { err = MP4BadParamErr; goto bail; }
 	
-	schm = (MP4SecuritySchemeAtomPtr) sinf->MP4SecurityScheme;
+	schm = (MP4SchemeTypeAtomPtr)sinf->MP4SchemeType;
 	if (!schm)  { err = MP4BadDataErr; goto bail; }
 	
 	*sch_type    = schm->scheme_type;

--- a/IsoLib/libisomediafile/src/ISOMeta.c
+++ b/IsoLib/libisomediafile/src/ISOMeta.c
@@ -1557,7 +1557,7 @@ ISONewMetaProtection( ISOMeta meta, u32 sch_type, u32 sch_version, char* sch_url
 	
 	ISOMetaAtomPtr myMeta;
 	MP4SecurityInfoAtomPtr sinf;
-	MP4SecuritySchemeAtomPtr schm;
+	MP4SchemeTypeAtomPtr schm;
 	MP4SchemeInfoAtomPtr schi;
 	ISOItemProtectionAtomPtr ipro;
 	u32 j;
@@ -1582,7 +1582,7 @@ ISONewMetaProtection( ISOMeta meta, u32 sch_type, u32 sch_version, char* sch_url
 	else schm->scheme_url = NULL;
 
 	err = MP4CreateSecurityInfoAtom( &sinf ); if (err) goto bail;
-	sinf->MP4SecurityScheme = (MP4AtomPtr) schm; schm = NULL;
+	sinf->MP4SchemeType = (MP4AtomPtr) schm; schm = NULL;
 	sinf->MP4SchemeInfo     = (MP4AtomPtr) schi; schi = NULL;
 	
 	ipro = (ISOItemProtectionAtomPtr) myMeta->ipro;
@@ -1638,7 +1638,7 @@ ISOGetMetaProtection( ISOMeta meta, u16 protection_index, u32* sch_type, u32* sc
 	
 	ISOMetaAtomPtr myMeta;
 	MP4SecurityInfoAtomPtr sinf;
-	MP4SecuritySchemeAtomPtr schm;
+	MP4SchemeTypeAtomPtr schm;
 	ISOItemProtectionAtomPtr ipro;
 	
 	err = MP4NoErr;
@@ -1648,7 +1648,7 @@ ISOGetMetaProtection( ISOMeta meta, u16 protection_index, u32* sch_type, u32* sc
 	if (!ipro) BAILWITHERROR( MP4BadParamErr);
 	err  = MP4GetListEntry( ipro->atomList, protection_index-1, (char **) &sinf ); if (err) goto bail;
 	
-	schm = (MP4SecuritySchemeAtomPtr) sinf->MP4SecurityScheme;
+	schm = (MP4SchemeTypeAtomPtr) sinf->MP4SchemeType;
 
 	*sch_type    = schm->scheme_type;
 	*sch_version = schm->scheme_version;

--- a/IsoLib/libisomediafile/src/ISOMeta.c
+++ b/IsoLib/libisomediafile/src/ISOMeta.c
@@ -1569,7 +1569,7 @@ ISONewMetaProtection( ISOMeta meta, u32 sch_type, u32 sch_version, char* sch_url
 
 	err = MP4CreateSchemeInfoAtom( &schi ); if (err) goto bail;
 	
-	err = MP4CreateSecuritySchemeAtom( &schm ); if (err) goto bail;
+	err = MP4CreateSchemeTypeAtom( &schm ); if (err) goto bail;
 	schm->scheme_type    = sch_type;
 	schm->scheme_version = sch_version;
 	

--- a/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
+++ b/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
@@ -1066,7 +1066,7 @@ MP4_EXTERN(MP4Err) ISOGetRESVSampleDescriptionPS(MP4Handle sampleEntryH,
 
     err = sampleEntryHToAtomPtr(sampleEntryH, (MP4AtomPtr *)&entry, MP4VisualSampleEntryAtomType); if (err) goto bail;
 
-    if (entry->type != MP4RestrictedVideoAtomType) BAILWITHERROR(MP4BadParamErr);
+    if (entry->type != MP4RestrictedVideoSampleEntryAtomType) BAILWITHERROR(MP4BadParamErr);
 
     err = MP4GetListEntryAtom(entry->ExtensionAtomList, ISOHEVCConfigAtomType, (MP4AtomPtr*)&config);
     if (err == MP4NotFoundErr) {
@@ -1096,7 +1096,7 @@ MP4_EXTERN(MP4Err) ISOGetRESVLengthSizeMinusOne(MP4Handle sampleEntryH, u32* out
       goto bail;
     }
 
-    if (entry->type != MP4RestrictedVideoAtomType) {
+    if (entry->type != MP4RestrictedVideoSampleEntryAtomType) {
       BAILWITHERROR(MP4BadParamErr);
     }
 
@@ -1120,16 +1120,16 @@ MP4_EXTERN(MP4Err) ISOGetRESVOriginalFormat(MP4Handle sampleEntryH,
 {
     MP4Err err = MP4NoErr;
     MP4VisualSampleEntryAtomPtr entry = NULL;
-    MP4RestrictedInfoAtomPtr    config;
+    MP4RestrictedSchemeInfoAtomPtr    config;
     MP4Handle rinfHandle;
 
     ISONewHandle(1, &rinfHandle);
 
     err = sampleEntryHToAtomPtr(sampleEntryH, (MP4AtomPtr *)&entry, MP4VisualSampleEntryAtomType); if (err) goto bail;
 
-    if (entry->type != MP4RestrictedVideoAtomType) BAILWITHERROR(MP4BadParamErr);
+    if (entry->type != MP4RestrictedVideoSampleEntryAtomType) BAILWITHERROR(MP4BadParamErr);
 
-    err = MP4GetListEntryAtom(entry->ExtensionAtomList, MP4RestrictedInfoAtomType, (MP4AtomPtr*)&config);
+    err = MP4GetListEntryAtom(entry->ExtensionAtomList, MP4RestrictedSchemeInfoAtomType, (MP4AtomPtr*)&config);
     if (err == MP4NotFoundErr) {
         BAILWITHERROR(MP4BadDataErr);
     }

--- a/IsoLib/libisomediafile/src/MP4Atoms.c
+++ b/IsoLib/libisomediafile/src/MP4Atoms.c
@@ -507,6 +507,10 @@ MP4Err MP4CreateAtom( u32 atomType, MP4AtomPtr *outAtom )
 			err = MP4CreateStereoVideoAtom((MP4StereoVideoAtomPtr *)&newAtom);
 			break;
 
+		case MP4StereoVideoGroupAtomType:
+			err = MP4CreateStereoVideoGroupAtom((MP4StereoVideoGroupAtomPtr *)&newAtom);
+			break;
+
 #ifdef ISMACrypt
 		case MP4SecurityInfoAtomType:
 			err = MP4CreateSecurityInfoAtom( (MP4SecurityInfoAtomPtr *) &newAtom );

--- a/IsoLib/libisomediafile/src/MP4Atoms.c
+++ b/IsoLib/libisomediafile/src/MP4Atoms.c
@@ -295,6 +295,10 @@ MP4Err MP4CreateAtom( u32 atomType, MP4AtomPtr *outAtom )
 			err = MP4CreateEncAudioSampleEntryAtom( (MP4EncAudioSampleEntryAtomPtr*) &newAtom );
 			break;
 
+		case MP4RestrictedVideoSampleEntryAtomType:
+			err = MP4CreateRestrictedVideoSampleEntryAtom( (MP4RestrictedVideoSampleEntryAtomPtr*) &newAtom );
+			break;
+
 		case MP4XMLMetaSampleEntryAtomType:
 			err = MP4CreateXMLMetaSampleEntryAtom( (MP4XMLMetaSampleEntryAtomPtr*) &newAtom );
 			break;
@@ -475,22 +479,34 @@ MP4Err MP4CreateAtom( u32 atomType, MP4AtomPtr *outAtom )
 			err = MP4CreateTrackRunAtom( (MP4TrackRunAtomPtr*) &newAtom );
 			break;
 
+		case MP4SchemeTypeAtomType:
+			err = MP4CreateSchemeTypeAtom( (MP4SchemeTypeAtomPtr *) &newAtom );
+			break;
+
+		case MP4OriginalFormatAtomType:
+			err = MP4CreateOriginalFormatAtom((MP4OriginalFormatAtomPtr *)&newAtom);
+			break;
+
+		case MP4SchemeInfoAtomType:
+			err = MP4CreateSchemeInfoAtom((MP4SchemeInfoAtomPtr *)&newAtom);
+			break;
+
+		case MP4CompatibleSchemeTypeAtomType:
+			err = MP4CreateCompatibleSchemeTypeAtom((MP4CompatibleSchemeTypeAtomPtr *)&newAtom);
+			break;
+
+		case MP4RestrictedSchemeInfoAtomType:
+			err = MP4CreateRestrictedSchemeInfoAtom((MP4RestrictedSchemeInfoAtomPtr *)&newAtom);
+			break;
+
 #ifdef ISMACrypt
 		case MP4SecurityInfoAtomType:
 			err = MP4CreateSecurityInfoAtom( (MP4SecurityInfoAtomPtr *) &newAtom );
 			break;
 		
-		case MP4OriginalFormatAtomType:
-			err = MP4CreateOriginalFormatAtom( (MP4OriginalFormatAtomPtr *) &newAtom );
-			break;
-		
-		case MP4SecuritySchemeAtomType:
-			err = MP4CreateSecuritySchemeAtom( (MP4SecuritySchemeAtomPtr *) &newAtom );
-			break;
-		
-		case MP4SchemeInfoAtomType:
-			err = MP4CreateSchemeInfoAtom( (MP4SchemeInfoAtomPtr *) &newAtom );
-			break;
+//		case MP4SecuritySchemeAtomType:
+//			err = MP4CreateSecuritySchemeAtom( (MP4SecuritySchemeAtomPtr *) &newAtom );
+//			break;
 		
 		case ISMAKMSAtomType:
 			err = CreateISMAKMSAtom( (ISMAKMSAtomPtr *) &newAtom );

--- a/IsoLib/libisomediafile/src/MP4Atoms.c
+++ b/IsoLib/libisomediafile/src/MP4Atoms.c
@@ -499,14 +499,18 @@ MP4Err MP4CreateAtom( u32 atomType, MP4AtomPtr *outAtom )
 			err = MP4CreateRestrictedSchemeInfoAtom((MP4RestrictedSchemeInfoAtomPtr *)&newAtom);
 			break;
 
+		case MP4TrackTypeAtomType:
+			err = MP4CreateTrackTypeAtom((MP4TrackTypeAtomPtr *) &newAtom);
+			break;
+
+		case MP4StereoVideoAtomType:
+			err = MP4CreateStereoVideoAtom((MP4StereoVideoAtomPtr *)&newAtom);
+			break;
+
 #ifdef ISMACrypt
 		case MP4SecurityInfoAtomType:
 			err = MP4CreateSecurityInfoAtom( (MP4SecurityInfoAtomPtr *) &newAtom );
 			break;
-		
-//		case MP4SecuritySchemeAtomType:
-//			err = MP4CreateSecuritySchemeAtom( (MP4SecuritySchemeAtomPtr *) &newAtom );
-//			break;
 		
 		case ISMAKMSAtomType:
 			err = CreateISMAKMSAtom( (ISMAKMSAtomPtr *) &newAtom );

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -1867,6 +1867,7 @@ MP4Err MP4CreateCompatibleSchemeTypeAtom(MP4CompatibleSchemeTypeAtomPtr *outAtom
 MP4Err MP4CreateRestrictedVideoSampleEntryAtom(MP4RestrictedVideoSampleEntryAtomPtr *outAtom);
 MP4Err MP4CreateTrackTypeAtom(MP4TrackTypeAtomPtr *outAtom);
 MP4Err MP4CreateStereoVideoAtom(MP4StereoVideoAtomPtr *outAtom);
+MP4Err MP4CreateStereoVideoGroupAtom(MP4StereoVideoGroupAtomPtr *outAtom);
 
 #ifdef ISMACrypt
 MP4Err MP4CreateSecurityInfoAtom( MP4SecurityInfoAtomPtr *outAtom );

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -1387,11 +1387,10 @@ typedef struct ISOFileTypeAtom
 
 
 
-//
+// Box type: 'ttyp'
 typedef struct MP4TrackTypeAtom
 {
 	MP4_FULL_ATOM
-	//MP4_BASE_ATOM
 
 	ISOErr(*addStandard)(struct MP4TrackTypeAtom *self, u32 standard);
 	ISOErr(*setBrand)(struct MP4TrackTypeAtom *self, u32 standard, u32 minorversion);
@@ -1436,7 +1435,6 @@ typedef struct MP4RestrictedSchemeInfoAtom
 	MP4AtomPtr MP4SchemeInfo;					// optional ('schi')
 
 	MP4LinkedList atomList;						// may contain one or more instances of CompatibleSchemeTypeBox
-	//MP4AtomPtr MP4CompatibleSchemeType;		//
 	
 	MP4Err(*addAtom)(struct MP4RestrictedSchemeInfoAtom* self, MP4AtomPtr atom);
 
@@ -1515,7 +1513,7 @@ typedef struct MP4SchemeInfoAtom
 
 #ifdef ISMACrypt
 
-// Box 'sinf'
+// Box type: 'sinf'
 typedef struct MP4SecurityInfoAtom
 {
 	MP4_BASE_ATOM
@@ -1877,10 +1875,11 @@ MP4Err MP4CreateRestrictedSchemeInfoAtom(MP4RestrictedSchemeInfoAtomPtr *outAtom
 MP4Err MP4CreateSchemeTypeAtom(MP4SchemeTypeAtomPtr *outAtom);
 MP4Err MP4CreateCompatibleSchemeTypeAtom(MP4CompatibleSchemeTypeAtomPtr *outAtom);
 MP4Err MP4CreateRestrictedVideoSampleEntryAtom(MP4RestrictedVideoSampleEntryAtomPtr *outAtom);
+MP4Err MP4CreateTrackTypeAtom(MP4TrackTypeAtomPtr *outAtom);
+MP4Err MP4CreateStereoVideoAtom(MP4StereoVideoAtomPtr *outAtom);
 
 #ifdef ISMACrypt
 MP4Err MP4CreateSecurityInfoAtom( MP4SecurityInfoAtomPtr *outAtom );
-//MP4Err MP4CreateSecuritySchemeAtom( MP4SecuritySchemeAtomPtr *outAtom );
 MP4Err CreateISMAKMSAtom( ISMAKMSAtomPtr *outAtom );
 MP4Err CreateISMASampleFormatAtom( ISMASampleFormatAtomPtr *outAtom );
 MP4Err CreateISMASaltAtom( ISMASaltAtomPtr *outAtom );

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -1434,7 +1434,11 @@ typedef struct MP4RestrictedSchemeInfoAtom
 	MP4AtomPtr MP4OriginalFormat;				//			('frma')
 	MP4AtomPtr MP4SchemeType;					//          ('schm')
 	MP4AtomPtr MP4SchemeInfo;					// optional ('schi')
+
+	MP4LinkedList atomList;						// may contain one or more instances of CompatibleSchemeTypeBox
 	//MP4AtomPtr MP4CompatibleSchemeType;		//
+	
+	MP4Err(*addAtom)(struct MP4RestrictedSchemeInfoAtom* self, MP4AtomPtr atom);
 
 } MP4RestrictedSchemeInfoAtom, *MP4RestrictedSchemeInfoAtomPtr;
 

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -166,23 +166,6 @@ enum {
 };
 #endif
 
-/*
-// restricted schemes and OMAF support
-enum {
-	// atom types
-	MP4OriginalFormatAtomType							= MP4_FOUR_CHAR_CODE( 'f', 'r', 'm', 'a' ),
-	MP4SchemeTypeAtomType								= MP4_FOUR_CHAR_CODE( 's', 'c', 'h', 'm' ),
-	MP4SchemeInfoAtomType								= MP4_FOUR_CHAR_CODE( 's', 'c', 'h', 'i' ),
-	MP4StereoVideoAtomType								= MP4_FOUR_CHAR_CODE( 's', 't', 'v', 'i'),
-	MP4CompatibleSchemeTypeAtomType						= MP4_FOUR_CHAR_CODE( 'c', 's', 'c', 'h' ),	
-	MP4RestrictedSchemeInfoAtomType						= MP4_FOUR_CHAR_CODE( 'r', 'i', 'n', 'f' ),
-	MP4TrackGroupTypeAtomType							= MP4_FOUR_CHAR_CODE( 's', 't', 'e', 'r' ),
-	MP4TrackTypeAtomType								= MP4_FOUR_CHAR_CODE( 't', 't', 'y', 'p' ),
-	// sample entry types
-	MP4RestrictedVideoSampleEntryAtomType				= MP4_FOUR_CHAR_CODE( 'r', 'e', 's', 'v' )
-};
-*/
-
 #define MP4_BASE_ATOM    \
 	u32	   type;         \
 	u8   uuid[16];       \
@@ -1396,9 +1379,6 @@ typedef struct ISOFileTypeAtom
 	u32 *compatibilityList;								/* standards this file conforms to */
 } ISOFileTypeAtom, *ISOFileTypeAtomPtr;
 
-
-
-// Box type: 'ttyp'
 typedef struct MP4TrackTypeAtom
 {
 	MP4_FULL_ATOM
@@ -1415,7 +1395,6 @@ typedef struct MP4TrackTypeAtom
 
 } MP4TrackTypeAtom, *MP4TrackTypeAtomPtr;
 
-// Box type: 'schm'
 typedef struct MP4SchemeTypeAtom
 {
 	MP4_FULL_ATOM
@@ -1426,7 +1405,6 @@ typedef struct MP4SchemeTypeAtom
 
 } MP4SchemeTypeAtom, *MP4SchemeTypeAtomPtr;
 
-// Box type: 'csch'
 typedef struct MP4CompatibleSchemeTypeAtom
 {
 	MP4_FULL_ATOM
@@ -1436,8 +1414,6 @@ typedef struct MP4CompatibleSchemeTypeAtom
 	char* scheme_url;
 } MP4CompatibleSchemeTypeAtom, *MP4CompatibleSchemeTypeAtomPtr;
 
-
-// Box type: 'rinf'
 typedef struct MP4RestrictedSchemeInfoAtom
 {
 	MP4_BASE_ATOM
@@ -1451,8 +1427,6 @@ typedef struct MP4RestrictedSchemeInfoAtom
 
 } MP4RestrictedSchemeInfoAtom, *MP4RestrictedSchemeInfoAtomPtr;
 
-
-// Box 'stvi'
 typedef struct MP4StereoVideoAtom {
 	
 	MP4_FULL_ATOM
@@ -1469,8 +1443,6 @@ typedef struct MP4StereoVideoAtom {
 
 } MP4StereoVideoAtom, *MP4StereoVideoAtomPtr;
 
-
-// Box 'resv'
 typedef struct MP4RestrictedVideoSampleEntryAtom {
 	MP4_BASE_ATOM
 	COMMON_SAMPLE_ENTRY_FIELDS
@@ -1501,7 +1473,6 @@ typedef struct MP4RestrictedVideoSampleEntryAtom {
 
 } MP4RestrictedVideoSampleEntryAtom, *MP4RestrictedVideoSampleEntryAtomPtr;
 
-// Common to both Restricted Video and Protection schemes
 typedef struct MP4OriginalFormatAtom
 {
 	MP4_BASE_ATOM
@@ -1509,7 +1480,6 @@ typedef struct MP4OriginalFormatAtom
 
 } MP4OriginalFormatAtom, *MP4OriginalFormatAtomPtr;
 
-// Common to both Restricted Video and Protection schemes
 typedef struct MP4SchemeInfoAtom
 {
 	MP4_BASE_ATOM
@@ -1523,8 +1493,6 @@ typedef struct MP4SchemeInfoAtom
 
 
 #ifdef ISMACrypt
-
-// Box type: 'sinf'
 typedef struct MP4SecurityInfoAtom
 {
 	MP4_BASE_ATOM

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -143,7 +143,6 @@ enum
     MP4H263SpecificInfoAtomType                         = MP4_FOUR_CHAR_CODE( 'd', '2', '6', '3' ),
     MP4BitRateAtomType                                  = MP4_FOUR_CHAR_CODE( 'b', 't', 'r', 't' ),
     TGPPBitRateAtomType                                 = MP4_FOUR_CHAR_CODE( 'b', 'i', 't', 'r' ),
-	// OMAF extensions
 	MP4OriginalFormatAtomType							= MP4_FOUR_CHAR_CODE( 'f', 'r', 'm', 'a' ),
 	MP4SchemeTypeAtomType								= MP4_FOUR_CHAR_CODE( 's', 'c', 'h', 'm' ),
 	MP4SchemeInfoAtomType								= MP4_FOUR_CHAR_CODE( 's', 'c', 'h', 'i' ),

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -142,7 +142,17 @@ enum
     MP4H263SampleEntryAtomType                          = MP4_FOUR_CHAR_CODE( 's', '2', '6', '3' ),
     MP4H263SpecificInfoAtomType                         = MP4_FOUR_CHAR_CODE( 'd', '2', '6', '3' ),
     MP4BitRateAtomType                                  = MP4_FOUR_CHAR_CODE( 'b', 't', 'r', 't' ),
-    TGPPBitRateAtomType                                 = MP4_FOUR_CHAR_CODE( 'b', 'i', 't', 'r' )
+    TGPPBitRateAtomType                                 = MP4_FOUR_CHAR_CODE( 'b', 'i', 't', 'r' ),
+	// OMAF extensions
+	MP4OriginalFormatAtomType							= MP4_FOUR_CHAR_CODE( 'f', 'r', 'm', 'a' ),
+	MP4SchemeTypeAtomType								= MP4_FOUR_CHAR_CODE( 's', 'c', 'h', 'm' ),
+	MP4SchemeInfoAtomType								= MP4_FOUR_CHAR_CODE( 's', 'c', 'h', 'i' ),
+	MP4StereoVideoAtomType								= MP4_FOUR_CHAR_CODE( 's', 't', 'v', 'i' ),
+	MP4CompatibleSchemeTypeAtomType						= MP4_FOUR_CHAR_CODE( 'c', 's', 'c', 'h' ),
+	MP4RestrictedSchemeInfoAtomType						= MP4_FOUR_CHAR_CODE( 'r', 'i', 'n', 'f' ),
+	MP4TrackGroupTypeAtomType							= MP4_FOUR_CHAR_CODE( 's', 't', 'e', 'r' ),
+	MP4TrackTypeAtomType								= MP4_FOUR_CHAR_CODE( 't', 't', 'y', 'p' ),
+	MP4RestrictedVideoSampleEntryAtomType				= MP4_FOUR_CHAR_CODE( 'r', 'e', 's', 'v' )
 }; 
 
 #ifdef ISMACrypt
@@ -157,6 +167,7 @@ enum {
 };
 #endif
 
+/*
 // restricted schemes and OMAF support
 enum {
 	// atom types
@@ -171,6 +182,7 @@ enum {
 	// sample entry types
 	MP4RestrictedVideoSampleEntryAtomType				= MP4_FOUR_CHAR_CODE( 'r', 'e', 's', 'v' )
 };
+*/
 
 #define MP4_BASE_ATOM    \
 	u32	   type;         \

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -148,9 +148,6 @@ enum
 #ifdef ISMACrypt
 enum {
     MP4SecurityInfoAtomType                             = MP4_FOUR_CHAR_CODE( 's', 'i', 'n', 'f' ),
-//    MP4OriginalFormatAtomType                           = MP4_FOUR_CHAR_CODE( 'f', 'r', 'm', 'a' ),
-//    MP4SecuritySchemeAtomType                           = MP4_FOUR_CHAR_CODE( 's', 'c', 'h', 'm' ),
-//    MP4SchemeInfoAtomType                               = MP4_FOUR_CHAR_CODE( 's', 'c', 'h', 'i' ),
     ISMAKMSAtomType                                     = MP4_FOUR_CHAR_CODE( 'i', 'K', 'M', 'S' ),
     ISMASampleFormatAtomType                            = MP4_FOUR_CHAR_CODE( 'i', 'S', 'F', 'M' ),
     ISMASaltAtomType                                    = MP4_FOUR_CHAR_CODE( 'i', 'S', 'L', 'T' ),
@@ -160,17 +157,19 @@ enum {
 };
 #endif
 
-/* restricted info atom types (same as sinf) */
+// restricted schemes and OMAF support
 enum {
-	MP4OriginalFormatAtomType							= MP4_FOUR_CHAR_CODE('f', 'r', 'm', 'a'),
-	MP4CompatibleSchemeTypeAtomType						= MP4_FOUR_CHAR_CODE('c', 's', 'c', 'h'),
-	MP4SchemeTypeAtomType								= MP4_FOUR_CHAR_CODE('s', 'c', 'h', 'm'),
-	MP4RestrictedSchemeInfoAtomType						= MP4_FOUR_CHAR_CODE('r', 'i', 'n', 'f'),
-	MP4SchemeInfoAtomType								= MP4_FOUR_CHAR_CODE('s', 'c', 'h', 'i'),
-	MP4TrackGroupTypeAtomType							= MP4_FOUR_CHAR_CODE('s', 't', 'e', 'r'),
-	MP4TrackTypeAtomType								= MP4_FOUR_CHAR_CODE('z', 'z', 'z', 'z'),  // TODO
+	// atom types
+	MP4OriginalFormatAtomType							= MP4_FOUR_CHAR_CODE( 'f', 'r', 'm', 'a' ),
+	MP4SchemeTypeAtomType								= MP4_FOUR_CHAR_CODE( 's', 'c', 'h', 'm' ),
+	MP4SchemeInfoAtomType								= MP4_FOUR_CHAR_CODE( 's', 'c', 'h', 'i' ),
+	MP4StereoVideoAtomType								= MP4_FOUR_CHAR_CODE( 's', 't', 'v', 'i'),
+	MP4CompatibleSchemeTypeAtomType						= MP4_FOUR_CHAR_CODE( 'c', 's', 'c', 'h' ),	
+	MP4RestrictedSchemeInfoAtomType						= MP4_FOUR_CHAR_CODE( 'r', 'i', 'n', 'f' ),
+	MP4TrackGroupTypeAtomType							= MP4_FOUR_CHAR_CODE( 's', 't', 'e', 'r' ),
+	MP4TrackTypeAtomType								= MP4_FOUR_CHAR_CODE( 't', 't', 'y', 'p' ),
 	// sample entry types
-	MP4RestrictedVideoSampleEntryAtomType				= MP4_FOUR_CHAR_CODE('r', 'e', 's', 'v')
+	MP4RestrictedVideoSampleEntryAtomType				= MP4_FOUR_CHAR_CODE( 'r', 'e', 's', 'v' )
 };
 
 #define MP4_BASE_ATOM    \
@@ -1391,17 +1390,17 @@ typedef struct ISOFileTypeAtom
 //
 typedef struct MP4TrackTypeAtom
 {
-	//MP4_FULL_ATOM
-	MP4_BASE_ATOM
+	MP4_FULL_ATOM
+	//MP4_BASE_ATOM
 
 	ISOErr(*addStandard)(struct MP4TrackTypeAtom *self, u32 standard);
 	ISOErr(*setBrand)(struct MP4TrackTypeAtom *self, u32 standard, u32 minorversion);
 	ISOErr(*getBrand)(struct MP4TrackTypeAtom *self, u32* standard, u32* minorversion);
 	u32(*getStandard)(struct MP4TrackTypeAtom *self, u32 standard);
 
-	u32 majorBrand;											/* the brand of this track */
-	u32 minorVersion;										/* the minor version of this track */
-	u32 itemCount;											/* the number of items in the compatibility list */
+	u32 majorBrand;										/* the brand of this track */
+	u32 minorVersion;									/* the minor version of this track */
+	u32 itemCount;										/* the number of items in the compatibility list */
 	u32 *compatibilityList;
 
 } MP4TrackTypeAtom, *MP4TrackTypeAtomPtr;
@@ -1417,7 +1416,7 @@ typedef struct MP4SchemeTypeAtom
 
 } MP4SchemeTypeAtom, *MP4SchemeTypeAtomPtr;
 
-// Box type: ''
+// Box type: 'csch'
 typedef struct MP4CompatibleSchemeTypeAtom
 {
 	MP4_FULL_ATOM
@@ -1438,6 +1437,25 @@ typedef struct MP4RestrictedSchemeInfoAtom
 	//MP4AtomPtr MP4CompatibleSchemeType;		//
 
 } MP4RestrictedSchemeInfoAtom, *MP4RestrictedSchemeInfoAtomPtr;
+
+
+// Box 'stvi'
+typedef struct MP4StereoVideoAtom {
+	
+	MP4_FULL_ATOM
+
+	u32		reserved;								// unsigned int(30) = 0
+	u8		single_view_allowed;					// unsigned int(2)	
+	u32		stereo_scheme;							// unsigned int(32)	
+	u32		length;									// unsigned int(32)
+	u8		*stereo_indication_type;				// unsigned int(8)[length]
+	
+	MP4LinkedList atomList;							// optional
+	
+	MP4Err(*addAtom)(struct MP4StereoVideoAtom* self, MP4AtomPtr atom);
+
+} MP4StereoVideoAtom, *MP4StereoVideoAtomPtr;
+
 
 // Box 'resv'
 typedef struct MP4RestrictedVideoSampleEntryAtom {

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -1401,7 +1401,7 @@ typedef struct MP4SchemeTypeAtom
 	u32	scheme_type;
 	u32 scheme_version;
 
-	char* scheme_url;  // if (flags & 0x000001), a scheme URL is present
+	char* scheme_url;  /* if (flags & 0x000001), a scheme URL is present */
 
 } MP4SchemeTypeAtom, *MP4SchemeTypeAtomPtr;
 
@@ -1417,11 +1417,11 @@ typedef struct MP4CompatibleSchemeTypeAtom
 typedef struct MP4RestrictedSchemeInfoAtom
 {
 	MP4_BASE_ATOM
-	MP4AtomPtr MP4OriginalFormat;				//			('frma')
-	MP4AtomPtr MP4SchemeType;					//          ('schm')
-	MP4AtomPtr MP4SchemeInfo;					// optional ('schi')
+	MP4AtomPtr MP4OriginalFormat;				/*			('frma') */
+	MP4AtomPtr MP4SchemeType;					/*          ('schm') */
+	MP4AtomPtr MP4SchemeInfo;					/* optional ('schi') */
 
-	MP4LinkedList atomList;						// may contain one or more instances of CompatibleSchemeTypeBox
+	MP4LinkedList atomList;						/* may contain one or more instances of CompatibleSchemeTypeBox */
 	
 	MP4Err(*addAtom)(struct MP4RestrictedSchemeInfoAtom* self, MP4AtomPtr atom);
 
@@ -1431,13 +1431,13 @@ typedef struct MP4StereoVideoAtom {
 	
 	MP4_FULL_ATOM
 
-	u32		reserved;								// unsigned int(30) = 0
-	u8		single_view_allowed;					// unsigned int(2)	
-	u32		stereo_scheme;							// unsigned int(32)	
-	u32		length;									// unsigned int(32)
-	u8		*stereo_indication_type;				// unsigned int(8)[length]
+	u32		reserved;								/* unsigned int(30) = 0 */
+	u8		single_view_allowed;					/* unsigned int(2) */
+	u32		stereo_scheme;							/* unsigned int(32)	*/
+	u32		length;									/* unsigned int(32) */
+	u8		*stereo_indication_type;				/* unsigned int(8)[length] */
 	
-	MP4LinkedList atomList;							// optional
+	MP4LinkedList atomList;							/* optional */
 	
 	MP4Err(*addAtom)(struct MP4StereoVideoAtom* self, MP4AtomPtr atom);
 

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -1484,7 +1484,7 @@ typedef struct MP4SchemeInfoAtom
 {
 	MP4_BASE_ATOM
 
-	MP4LinkedList atomList;  // this atom may include a variable number of atoms
+	MP4LinkedList atomList;  /* this atom may include a variable number of atoms */
 	ISOErr(*addAtom)(struct MP4SchemeInfoAtom* self, MP4AtomPtr atom);
 
 } MP4SchemeInfoAtom, *MP4SchemeInfoAtomPtr;

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -149,7 +149,7 @@ enum
 	MP4StereoVideoAtomType								= MP4_FOUR_CHAR_CODE( 's', 't', 'v', 'i' ),
 	MP4CompatibleSchemeTypeAtomType						= MP4_FOUR_CHAR_CODE( 'c', 's', 'c', 'h' ),
 	MP4RestrictedSchemeInfoAtomType						= MP4_FOUR_CHAR_CODE( 'r', 'i', 'n', 'f' ),
-	MP4TrackGroupTypeAtomType							= MP4_FOUR_CHAR_CODE( 's', 't', 'e', 'r' ),
+	MP4StereoVideoGroupAtomType						    = MP4_FOUR_CHAR_CODE( 's', 't', 'e', 'r' ),
 	MP4TrackTypeAtomType								= MP4_FOUR_CHAR_CODE( 't', 't', 'y', 'p' ),
 	MP4RestrictedVideoSampleEntryAtomType				= MP4_FOUR_CHAR_CODE( 'r', 'e', 's', 'v' )
 }; 
@@ -1442,6 +1442,17 @@ typedef struct MP4StereoVideoAtom {
 	MP4Err(*addAtom)(struct MP4StereoVideoAtom* self, MP4AtomPtr atom);
 
 } MP4StereoVideoAtom, *MP4StereoVideoAtomPtr;
+
+typedef struct MP4StereoVideoGroupAtom {
+
+	MP4_FULL_ATOM
+
+	u32 trackGroupID;								/* unsigned int(32), inherited from TrackGroupTypeAtom */
+
+	u8 leftViewFlag;								/* unsigned int(1) */
+	char reserved[4];								/* bit(31) = 0 */
+
+} MP4StereoVideoGroupAtom, *MP4StereoVideoGroupAtomPtr;
 
 typedef struct MP4RestrictedVideoSampleEntryAtom {
 	MP4_BASE_ATOM

--- a/IsoLib/libisomediafile/src/OriginalFormatAtom.c
+++ b/IsoLib/libisomediafile/src/OriginalFormatAtom.c
@@ -106,7 +106,7 @@ MP4Err MP4CreateOriginalFormatAtom( MP4OriginalFormatAtomPtr *outAtom )
 	err = MP4CreateBaseAtom( (MP4AtomPtr) self );
 	if ( err ) goto bail;
 	self->type = MP4OriginalFormatAtomType;
-	self->name                = "OriginalFormat";
+	self->name                = "OriginalFormatBox";
 	self->createFromInputStream = (cisfunc) createFromInputStream;
 	self->destroy             = destroy;
 	self->calculateSize         = calculateSize;

--- a/IsoLib/libisomediafile/src/RestrictedSchemeInfoAtom.c
+++ b/IsoLib/libisomediafile/src/RestrictedSchemeInfoAtom.c
@@ -1,0 +1,185 @@
+
+#include "MP4Atoms.h"
+#include <stdlib.h>
+#include <string.h>
+
+
+
+static void destroy(MP4AtomPtr s)
+{
+	MP4Err err;
+
+	MP4RestrictedSchemeInfoAtomPtr self = (MP4RestrictedSchemeInfoAtomPtr)s;
+	err = MP4NoErr;
+
+	if (self == NULL)
+		BAILWITHERROR(MP4BadParamErr)
+	if (self->MP4OriginalFormat)
+	{
+		self->MP4OriginalFormat->destroy(self->MP4OriginalFormat);
+		self->MP4OriginalFormat = NULL;
+	}
+	if (self->MP4SchemeType)
+	{
+		self->MP4SchemeType->destroy(self->MP4SchemeType);
+		self->MP4SchemeType = NULL;
+	}
+	if (self->MP4SchemeInfo)
+	{
+		self->MP4SchemeInfo->destroy(self->MP4SchemeInfo);
+		self->MP4SchemeInfo = NULL;
+	}
+	// Ahmed: This should be a list (zero or more CompatibleSchemeTypeBox are possible)
+	/*
+	if (self->MP4CompatibleSchemeType)
+	{
+	// TODO
+	}
+	*/
+
+	if (self->super)
+		self->super->destroy(s);
+bail:
+	TEST_RETURN(err);
+
+	return;
+}
+
+static MP4Err serialize(struct MP4Atom* s, char* buffer)
+{
+	MP4Err err;
+	MP4RestrictedSchemeInfoAtomPtr self = (MP4RestrictedSchemeInfoAtomPtr)s;
+	err = MP4NoErr;
+
+	err = MP4SerializeCommonBaseAtomFields(s, buffer); if (err) goto bail;
+	buffer += self->bytesWritten;
+
+	/* PUT32_V( 0 );	*/	/* version/flags */
+
+	SERIALIZE_ATOM(MP4OriginalFormat);
+	SERIALIZE_ATOM(MP4SchemeType);
+	SERIALIZE_ATOM(MP4SchemeInfo);
+	//SERIALIZE_ATOM(MP4CompatibleSchemeType);
+
+	assert(self->bytesWritten == self->size);
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err calculateSize(struct MP4Atom* s)
+{
+	MP4Err err;
+	MP4RestrictedSchemeInfoAtomPtr self = (MP4RestrictedSchemeInfoAtomPtr)s;
+	err = MP4NoErr;
+
+	err = MP4CalculateBaseAtomFieldSize(s); if (err) goto bail;
+	self->size += 0;		/* version/flags */
+	ADD_ATOM_SIZE(MP4OriginalFormat);
+	ADD_ATOM_SIZE(MP4SchemeType);
+	ADD_ATOM_SIZE(MP4SchemeInfo);
+	//ADD_ATOM_SIZE(MP4CompatibleSchemeType);
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+#define ADDCASE( atomName ) \
+		case atomName ## AtomType: \
+if (self->atomName) \
+	BAILWITHERROR(MP4BadDataErr) \
+	self->atomName = atom; \
+	break
+
+
+
+static MP4Err addAtom(MP4RestrictedSchemeInfoAtomPtr self, MP4AtomPtr atom)
+{
+	MP4Err err;
+	err = MP4NoErr;
+	switch (atom->type)
+	{
+		ADDCASE(MP4OriginalFormat);
+		ADDCASE(MP4SchemeType);
+		ADDCASE(MP4SchemeInfo);
+
+	default:
+		/* TODO: this default is wrong; we should be tolerant and accept unknown atoms */
+		//err = MP4InvalidMediaErr;
+		goto bail;
+		break;
+	}
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStreamPtr inputStream)
+{
+
+	PARSE_ATOM_LIST(MP4RestrictedSchemeInfoAtom)
+
+#if 0
+		MP4Err err; \
+
+		MP4RestrictedSchemeInfoAtomPtr self = (MP4RestrictedSchemeInfoAtomPtr)s; \
+
+		err = MP4NoErr; \
+	if (self == NULL)	BAILWITHERROR(MP4BadParamErr) \
+		err = self->super->createFromInputStream(s, proto, (char*)inputStream); if (err) goto bail; \
+		GET32_V(junk);			/* version/flags */
+	while (self->bytesRead < self->size) \
+	{ \
+	MP4AtomPtr atom; \
+	err = MP4ParseAtom((MP4InputStreamPtr)inputStream, &atom); \
+	if (err) goto bail; \
+		self->bytesRead += atom->size; \
+	if (((atom->type) == MP4FreeSpaceAtomType) || ((atom->type) == MP4SkipAtomType)) \
+		atom->destroy(atom); \
+	else {
+		\
+			err = addAtom(self, atom); \
+		if (err) goto bail; \
+	} \
+	} \
+	if (self->bytesRead != self->size) \
+		BAILWITHERROR(MP4BadDataErr) \
+
+#endif
+
+
+	bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+
+
+MP4Err MP4CreateRestrictedSchemeInfoAtom(MP4RestrictedSchemeInfoAtomPtr *outAtom)
+{
+	MP4Err err;
+	MP4RestrictedSchemeInfoAtomPtr self;
+
+	self = (MP4RestrictedSchemeInfoAtomPtr)calloc(1, sizeof(MP4RestrictedSchemeInfoAtom));
+	TESTMALLOC(self);
+
+	err = MP4CreateBaseAtom((MP4AtomPtr)self);
+	if (err) goto bail;
+
+	self->type = MP4RestrictedSchemeInfoAtomType;
+	self->name = "RestrictedSchemeInfo";
+	self->createFromInputStream = (cisfunc)createFromInputStream;
+	self->destroy = destroy;
+	self->calculateSize = calculateSize;
+	self->serialize = serialize;
+
+	*outAtom = self;
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}

--- a/IsoLib/libisomediafile/src/RestrictedSchemeInfoAtom.c
+++ b/IsoLib/libisomediafile/src/RestrictedSchemeInfoAtom.c
@@ -14,6 +14,7 @@ static void destroy(MP4AtomPtr s)
 
 	if (self == NULL)
 		BAILWITHERROR(MP4BadParamErr)
+	
 	if (self->MP4OriginalFormat)
 	{
 		self->MP4OriginalFormat->destroy(self->MP4OriginalFormat);
@@ -171,7 +172,7 @@ MP4Err MP4CreateRestrictedSchemeInfoAtom(MP4RestrictedSchemeInfoAtomPtr *outAtom
 	if (err) goto bail;
 
 	self->type = MP4RestrictedSchemeInfoAtomType;
-	self->name = "RestrictedSchemeInfo";
+	self->name = "RestrictedSchemeInfoBox";
 	self->createFromInputStream = (cisfunc)createFromInputStream;
 	self->destroy = destroy;
 	self->calculateSize = calculateSize;

--- a/IsoLib/libisomediafile/src/RestrictedSchemeInfoAtom.c
+++ b/IsoLib/libisomediafile/src/RestrictedSchemeInfoAtom.c
@@ -1,3 +1,35 @@
+/*
+ * This software module was originally developed by InterDigital, Inc.
+ * in the course of development of MPEG-4.
+ * This software module is an implementation of a part of one or
+ * more MPEG-4 tools as specified by MPEG-4.
+ * ISO/IEC gives users of MPEG-4 free license to this
+ * software module or modifications thereof for use in hardware
+ * or software products claiming conformance to MPEG-4 only for evaluation and testing purposes.
+ * Those intending to use this software module in hardware or software
+ * products are advised that its use may infringe existing patents.
+ * The original developer of this software module and his/her company,
+ * the subsequent editors and their companies, and ISO/IEC have no
+ * liability for use of this software module or modifications thereof
+ * in an implementation.
+ *
+ * Copyright is not released for non MPEG-4 conforming 
+ * products. InterDigital, Inc. retains full right to use the code for its own
+ * purpose, assign or donate the code to a third party and to
+ * inhibit third parties from using the code for non
+ * MPEG-4 conforming products.
+ *
+ * This copyright notice must be included in all copies or
+ * derivative works.
+ */
+
+/**
+ * @file RestrictedSchemeInfoAtom.c
+ * @author Ahmed Hamza <Ahmed.Hamza@InterDigital.com>
+ * @date January 19, 2018
+ * @brief Implements functions for reading and writing RestrictedSchemeInfoAtom instances.
+ */
+
 
 #include "MP4Atoms.h"
 #include <stdlib.h>

--- a/IsoLib/libisomediafile/src/RestrictedSchemeInfoAtom.c
+++ b/IsoLib/libisomediafile/src/RestrictedSchemeInfoAtom.c
@@ -142,13 +142,13 @@ MP4Err MP4CreateRestrictedSchemeInfoAtom(MP4RestrictedSchemeInfoAtomPtr *outAtom
 
 	err = MP4CreateBaseAtom((MP4AtomPtr)self); if (err) goto bail;
 
-	self->type = MP4RestrictedSchemeInfoAtomType;
-	self->name = "RestrictedSchemeInfoBox";
-	self->createFromInputStream = (cisfunc)createFromInputStream;
-	self->destroy = destroy;
-	self->calculateSize = calculateSize;
-	self->serialize = serialize;
-	self->addAtom = addAtom;
+	self->type						= MP4RestrictedSchemeInfoAtomType;
+	self->name						= "RestrictedSchemeInfoBox";
+	self->createFromInputStream		= (cisfunc)createFromInputStream;
+	self->destroy					= destroy;
+	self->calculateSize				= calculateSize;
+	self->serialize					= serialize;
+	self->addAtom					= addAtom;
 
 	err = MP4MakeLinkedList(&self->atomList); if (err) goto bail;
 

--- a/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
+++ b/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
@@ -1,0 +1,367 @@
+#include "MP4Atoms.h"
+#include <stdlib.h>
+#include <string.h>
+
+
+static void destroy(MP4AtomPtr s)
+{
+	MP4Err err;
+	MP4RestrictedVideoSampleEntryAtomPtr self;
+	err = MP4NoErr;
+	self = (MP4RestrictedVideoSampleEntryAtomPtr)s;
+	if (self == NULL)
+		BAILWITHERROR(MP4BadParamErr)
+
+	if (self->MP4RestrictedSchemeInfo)
+	{
+		self->MP4RestrictedSchemeInfo->destroy(self->MP4RestrictedSchemeInfo);
+		self->MP4RestrictedSchemeInfo = NULL;
+	}
+	DESTROY_ATOM_LIST_F(ExtensionAtomList)
+
+	if (self->super)
+		self->super->destroy(s);
+bail:
+	TEST_RETURN(err);
+
+	return;
+}
+
+static MP4Err serialize(struct MP4Atom* s, char* buffer)
+{
+	MP4Err err;
+	MP4RestrictedVideoSampleEntryAtomPtr self = (MP4RestrictedVideoSampleEntryAtomPtr)s;
+	err = MP4NoErr;
+
+	err = MP4SerializeCommonBaseAtomFields(s, buffer); if (err) goto bail;
+	buffer += self->bytesWritten;
+
+	PUTBYTES(self->reserved1, 6);
+	PUT16(dataReferenceIndex);
+	PUTBYTES(self->reserved2, 16);
+	PUT16(width);
+	PUT16(height);
+	/* PUT32( reserved3 ); */
+	PUT32(reserved4);
+	PUT32(reserved5);
+	PUT32(reserved6);
+	PUT16(reserved7);
+	PUT8(nameLength);
+	PUTBYTES(self->name31, 31);
+	PUT16(reserved8);
+	PUT16(reserved9);
+
+	SERIALIZE_ATOM_LIST(ExtensionAtomList);
+	SERIALIZE_ATOM(MP4RestrictedSchemeInfo);
+
+	assert(self->bytesWritten == self->size);
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err calculateSize(struct MP4Atom* s)
+{
+	MP4Err err;
+	MP4RestrictedVideoSampleEntryAtomPtr self = (MP4RestrictedVideoSampleEntryAtomPtr)s;
+	err = MP4NoErr;
+
+	err = MP4CalculateBaseAtomFieldSize(s); if (err) goto bail;
+	self->size += (6 + 16 + 31 + (4 * 2) + (1 * 1) + (4 * 4));  // TODO this probably includes restriction_type
+	ADD_ATOM_SIZE(MP4RestrictedSchemeInfo);
+	ADD_ATOM_LIST_SIZE(ExtensionAtomList);
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err addAtom(MP4RestrictedVideoSampleEntryAtomPtr self, MP4AtomPtr atom)
+{
+	MP4Err err;
+	err = MP4NoErr;
+	if (atom == NULL)
+		BAILWITHERROR(MP4BadParamErr);
+	if (atom->type == MP4RestrictedSchemeInfoAtomType)
+		self->MP4RestrictedSchemeInfo = atom;
+	else { err = MP4AddListEntry(atom, self->ExtensionAtomList); if (err) goto bail; }
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStreamPtr inputStream)
+{
+	MP4Err err;
+	MP4RestrictedVideoSampleEntryAtomPtr self = (MP4RestrictedVideoSampleEntryAtomPtr)s;
+
+	err = MP4NoErr;
+	if (self == NULL)	BAILWITHERROR(MP4BadParamErr)
+		err = self->super->createFromInputStream(s, proto, (char*)inputStream); if (err) goto bail;
+
+	GETBYTES(6, reserved1);
+	GET16(dataReferenceIndex);
+	GETBYTES(16, reserved2);
+	GET16(width);
+	GET16(height);
+	/* GET32( reserved3 ); */
+	GET32(reserved4);
+	GET32(reserved5);
+	GET32(reserved6);
+	GET16(reserved7);
+	GET8(nameLength);
+	GETBYTES(31, name31);
+	GET16(reserved8);
+	GET16(reserved9);
+	while (self->bytesRead < self->size)
+	{
+		MP4AtomPtr atom;
+		err = MP4ParseAtom((MP4InputStreamPtr)inputStream, &atom);
+		if (err) goto bail;
+		self->bytesRead += atom->size;
+		if (((atom->type) == MP4FreeSpaceAtomType) || ((atom->type) == MP4SkipAtomType))
+			atom->destroy(atom);
+		else {
+			err = addAtom(self, atom);
+			if (err) goto bail;
+		}
+	}
+
+	if (self->bytesRead != self->size)
+		BAILWITHERROR(MP4BadDataErr)
+
+	bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+
+
+static MP4Err transform(struct MP4Atom *s, u32 sch_type, u32 sch_version, char* sch_url)
+{
+	MP4Err err;
+
+	MP4RestrictedVideoSampleEntryAtomPtr self = (MP4RestrictedVideoSampleEntryAtomPtr)s;
+
+	MP4RestrictedSchemeInfoAtomPtr rinf;
+	MP4OriginalFormatAtomPtr frma;
+	MP4SchemeTypeAtomPtr schm;
+	MP4SchemeInfoAtomPtr schi;
+	char* sch_url_copy = NULL;
+
+	// 
+	err = MP4CreateOriginalFormatAtom(&frma); if (err) goto bail;
+	frma->original_format = self->type;
+
+	//
+	err = MP4CreateSchemeInfoAtom(&schi); if (err) goto bail;
+
+	//
+	err = MP4CreateSchemeTypeAtom(&schm); if (err) goto bail;
+	schm->scheme_type = sch_type;
+	schm->scheme_version = sch_version;
+
+	if (sch_url) {
+		sch_url_copy = (char*)calloc(1, strlen(sch_url) + 1);
+		TESTMALLOC(sch_url_copy);
+		memcpy(sch_url_copy, sch_url, strlen(sch_url) + 1);
+		schm->scheme_url = sch_url_copy; sch_url_copy = NULL;
+	}
+	else schm->scheme_url = NULL;
+
+	// create 'rinf' atom
+	err = MP4CreateRestrictedSchemeInfoAtom(&rinf); if (err) goto bail;
+
+	// assign
+	rinf->MP4OriginalFormat = (MP4AtomPtr)frma; frma = NULL;
+	rinf->MP4SchemeType = (MP4AtomPtr)schm; schm = NULL;
+	rinf->MP4SchemeInfo = (MP4AtomPtr)schi; schi = NULL;
+
+	self->type = self->restriction_type;
+
+	// set
+	self->MP4RestrictedSchemeInfo = (MP4AtomPtr)rinf;
+
+bail:
+	if (frma)  frma->destroy((MP4AtomPtr)frma);
+	if (schm) schm->destroy((MP4AtomPtr)schm);
+	if (schi) schi->destroy((MP4AtomPtr)schi);
+	if (sch_url_copy) free(sch_url_copy);
+
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err untransform(struct MP4Atom *s)
+{
+	MP4Err err;
+
+	MP4RestrictedVideoSampleEntryAtomPtr self = (MP4RestrictedVideoSampleEntryAtomPtr)s;
+	MP4OriginalFormatAtomPtr fmt;
+	MP4RestrictedSchemeInfoAtomPtr rinf;
+
+	err = MP4NoErr;
+
+	rinf = (MP4RestrictedSchemeInfoAtomPtr)self->MP4RestrictedSchemeInfo;
+	if (!rinf) { err = MP4BadParamErr; goto bail; }
+
+	fmt = (MP4OriginalFormatAtomPtr)rinf->MP4OriginalFormat;
+	if (!fmt)  { err = MP4BadDataErr; goto bail; }
+
+	self->type = fmt->original_format;
+	self->MP4RestrictedSchemeInfo = NULL;
+
+	rinf->destroy((MP4AtomPtr)rinf);
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err addSchemeInfoAtom(struct MP4Atom *s, struct MP4Atom *theAtom)
+{
+	MP4Err err;
+
+	MP4RestrictedVideoSampleEntryAtomPtr self = (MP4RestrictedVideoSampleEntryAtomPtr)s;
+	MP4SchemeInfoAtomPtr  schi;
+	MP4RestrictedSchemeInfoAtomPtr rinf;
+
+	rinf = (MP4RestrictedSchemeInfoAtomPtr)self->MP4RestrictedSchemeInfo;
+	if (!rinf) { err = MP4BadParamErr; goto bail; }
+
+	schi = (MP4SchemeInfoAtomPtr)rinf->MP4SchemeInfo;
+	if (!schi)  { err = MP4BadDataErr; goto bail; }
+
+	err = schi->addAtom(schi, theAtom); if (err) goto bail;
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err getSchemeInfoAtom(struct MP4Atom *s, u32 theType, struct MP4Atom **theAtom)
+{
+	MP4Err err;
+
+	MP4RestrictedVideoSampleEntryAtomPtr self = (MP4RestrictedVideoSampleEntryAtomPtr)s;
+	MP4SchemeInfoAtomPtr  schi;
+	MP4RestrictedSchemeInfoAtomPtr rinf;
+
+	err = MP4NoErr;
+
+	rinf = (MP4RestrictedSchemeInfoAtomPtr)self->MP4RestrictedSchemeInfo;
+	if (!rinf) { err = MP4BadParamErr; goto bail; }
+
+	schi = (MP4SchemeInfoAtomPtr)rinf->MP4SchemeInfo;
+	if (!schi)  { err = MP4BadDataErr; goto bail; }
+
+	err = MP4BadParamErr;
+	*theAtom = NULL;
+
+	if (schi->atomList)
+	{
+		u32 count;
+		u32 i;
+		struct MP4Atom* desc;
+		err = MP4GetListEntryCount(schi->atomList, &count); if (err) goto bail;
+		for (i = 0; i < count; i++)
+		{
+			err = MP4GetListEntry(schi->atomList, i, (char **)&desc); if (err) goto bail;
+			if (desc && (desc->type == theType))
+			{
+				*theAtom = desc;
+				break;
+				err = MP4NoErr;
+			}
+		}
+	}
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err getScheme(struct MP4Atom *s, u32* sch_type, u32* sch_version, char** sch_url)
+{
+	MP4Err err;
+
+	MP4RestrictedVideoSampleEntryAtomPtr self = (MP4RestrictedVideoSampleEntryAtomPtr)s;
+	MP4SchemeTypeAtomPtr schm;
+	MP4RestrictedSchemeInfoAtomPtr rinf;
+	char* sch_url_copy;
+
+	err = MP4NoErr;
+
+	rinf = (MP4RestrictedSchemeInfoAtomPtr)self->MP4RestrictedSchemeInfo;
+	if (!rinf) { err = MP4BadParamErr; goto bail; }
+
+	schm = (MP4SchemeTypeAtomPtr)rinf->MP4SchemeType;
+	if (!schm)  { err = MP4BadDataErr; goto bail; }
+
+	*sch_type = schm->scheme_type;
+	*sch_version = schm->scheme_version;
+
+	if (sch_url) {
+		sch_url_copy = (char*)calloc(1, strlen(schm->scheme_url) + 1);
+		TESTMALLOC(sch_url_copy);
+		memcpy(sch_url_copy, schm->scheme_url, strlen(schm->scheme_url) + 1);
+		*sch_url = sch_url_copy;
+	}
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+
+
+MP4Err MP4CreateRestrictedVideoSampleEntryAtom(MP4RestrictedVideoSampleEntryAtomPtr *outAtom)
+{
+	MP4Err err;
+	MP4RestrictedVideoSampleEntryAtomPtr self;
+
+	self = (MP4RestrictedVideoSampleEntryAtomPtr)calloc(1, sizeof(MP4RestrictedVideoSampleEntryAtom));
+	TESTMALLOC(self);
+
+	err = MP4CreateBaseAtom((MP4AtomPtr)self);
+	if (err) goto bail;
+
+	self->untransform = untransform;
+	self->addSchemeInfoAtom = addSchemeInfoAtom;
+	self->getSchemeInfoAtom = getSchemeInfoAtom;
+	self->getScheme = getScheme;
+	self->transform = transform;
+
+	err = MP4MakeLinkedList(&self->ExtensionAtomList); if (err) goto bail;
+
+	self->type = MP4RestrictedVideoSampleEntryAtomType;
+	self->name = "Restricted Video Sample Entry";
+	self->createFromInputStream = (cisfunc)createFromInputStream;
+	self->destroy = destroy;
+	self->calculateSize = calculateSize;
+	self->serialize = serialize;
+	self->restriction_type = MP4RestrictedVideoSampleEntryAtomType;
+
+	self->width = 0x140;
+	self->height = 0xf0;
+	self->reserved4 = 0x00480000;
+	self->reserved5 = 0x00480000;
+	self->reserved7 = 1;
+	self->reserved8 = 0x18;
+	self->reserved9 = -1;
+
+	*outAtom = self;
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}

--- a/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
+++ b/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
@@ -101,7 +101,7 @@ static MP4Err calculateSize(struct MP4Atom* s)
 	err = MP4NoErr;
 
 	err = MP4CalculateBaseAtomFieldSize(s); if (err) goto bail;
-	self->size += (6 + 16 + 31 + (4 * 2) + (1 * 1) + (4 * 4));  // TODO this probably includes restriction_type
+	self->size += (6 + 16 + 31 + (4 * 2) + (1 * 1) + (4 * 4));  /* TODO this probably includes restriction_type */
 	ADD_ATOM_SIZE(MP4RestrictedSchemeInfo);
 	ADD_ATOM_LIST_SIZE(ExtensionAtomList);
 bail:
@@ -185,14 +185,11 @@ static MP4Err transform(struct MP4Atom *s, u32 sch_type, u32 sch_version, char* 
 	MP4SchemeInfoAtomPtr schi;
 	char* sch_url_copy = NULL;
 
-	// 
 	err = MP4CreateOriginalFormatAtom(&frma); if (err) goto bail;
 	frma->original_format = self->type;
 
-	//
 	err = MP4CreateSchemeInfoAtom(&schi); if (err) goto bail;
 
-	//
 	err = MP4CreateSchemeTypeAtom(&schm); if (err) goto bail;
 	schm->scheme_type = sch_type;
 	schm->scheme_version = sch_version;
@@ -205,17 +202,17 @@ static MP4Err transform(struct MP4Atom *s, u32 sch_type, u32 sch_version, char* 
 	}
 	else schm->scheme_url = NULL;
 
-	// create 'rinf' atom
+	/* create 'rinf' atom */
 	err = MP4CreateRestrictedSchemeInfoAtom(&rinf); if (err) goto bail;
 
-	// assign
+	/* assign */
 	rinf->MP4OriginalFormat = (MP4AtomPtr)frma; frma = NULL;
 	rinf->MP4SchemeType = (MP4AtomPtr)schm; schm = NULL;
 	rinf->MP4SchemeInfo = (MP4AtomPtr)schi; schi = NULL;
 
 	self->type = self->restriction_type;
 
-	// set
+	/* set */
 	self->MP4RestrictedSchemeInfo = (MP4AtomPtr)rinf;
 
 bail:

--- a/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
+++ b/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
@@ -1,3 +1,35 @@
+/*
+ * This software module was originally developed by InterDigital, Inc.
+ * in the course of development of MPEG-4.
+ * This software module is an implementation of a part of one or
+ * more MPEG-4 tools as specified by MPEG-4.
+ * ISO/IEC gives users of MPEG-4 free license to this
+ * software module or modifications thereof for use in hardware
+ * or software products claiming conformance to MPEG-4 only for evaluation and testing purposes.
+ * Those intending to use this software module in hardware or software
+ * products are advised that its use may infringe existing patents.
+ * The original developer of this software module and his/her company,
+ * the subsequent editors and their companies, and ISO/IEC have no
+ * liability for use of this software module or modifications thereof
+ * in an implementation.
+ *
+ * Copyright is not released for non MPEG-4 conforming
+ * products. InterDigital, Inc. retains full right to use the code for its own
+ * purpose, assign or donate the code to a third party and to
+ * inhibit third parties from using the code for non
+ * MPEG-4 conforming products.
+ *
+ * This copyright notice must be included in all copies or
+ * derivative works.
+ */
+
+/**
+ * @file RestrictedVideoSampleEntry.c
+ * @author Ahmed Hamza <Ahmed.Hamza@InterDigital.com>
+ * @date January 19, 2018
+ * @brief Implements functions for reading and writing RestrictedVideoSampleEntryAtom instances.
+ */
+
 #include "MP4Atoms.h"
 #include <stdlib.h>
 #include <string.h>

--- a/IsoLib/libisomediafile/src/SchemeInfoAtom.c
+++ b/IsoLib/libisomediafile/src/SchemeInfoAtom.c
@@ -148,16 +148,17 @@ MP4Err MP4CreateSchemeInfoAtom( MP4SchemeInfoAtomPtr *outAtom )
 	self = (MP4SchemeInfoAtomPtr) calloc( 1, sizeof(MP4SchemeInfoAtom) );
 	TESTMALLOC( self );
 
-	err = MP4CreateBaseAtom( (MP4AtomPtr) self );
-	if ( err ) goto bail;
-	self->type = 			MP4SchemeInfoAtomType;
-	self->name                = "SchemeInformationBox";
-	err = MP4MakeLinkedList( &self->atomList ); if (err) goto bail;
-	self->createFromInputStream = (cisfunc) createFromInputStream;
-	self->destroy             = destroy;
-	self->calculateSize         = calculateSize;
-	self->serialize             = serialize;
-	self->addAtom				= addAtom;
+	err = MP4CreateBaseAtom( (MP4AtomPtr) self ); if ( err ) goto bail;
+
+	self->type						= MP4SchemeInfoAtomType;
+	self->name						= "SchemeInformationBox";
+	self->createFromInputStream		= (cisfunc) createFromInputStream;
+	self->destroy					= destroy;
+	self->calculateSize				= calculateSize;
+	self->serialize					= serialize;
+	self->addAtom					= addAtom;
+
+	err = MP4MakeLinkedList(&self->atomList); if (err) goto bail;
 
 	*outAtom = self;
 bail:

--- a/IsoLib/libisomediafile/src/SchemeInfoAtom.c
+++ b/IsoLib/libisomediafile/src/SchemeInfoAtom.c
@@ -28,7 +28,7 @@ derivative works. Copyright (c) 1999.
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef ISMACrypt
+
 
 static void destroy( MP4AtomPtr s )
 {
@@ -38,8 +38,9 @@ static void destroy( MP4AtomPtr s )
 	MP4SchemeInfoAtomPtr self = (MP4SchemeInfoAtomPtr) s;
     err = MP4NoErr;
 
-	if ( self == NULL )
-		BAILWITHERROR( MP4BadParamErr )
+	if (self == NULL)
+		BAILWITHERROR(MP4BadParamErr);
+
 	DESTROY_ATOM_LIST
 
 	if ( self->super )
@@ -150,7 +151,7 @@ MP4Err MP4CreateSchemeInfoAtom( MP4SchemeInfoAtomPtr *outAtom )
 	err = MP4CreateBaseAtom( (MP4AtomPtr) self );
 	if ( err ) goto bail;
 	self->type = 			MP4SchemeInfoAtomType;
-	self->name                = "MP4SchemeInfo";
+	self->name                = "SchemeInformationBox";
 	err = MP4MakeLinkedList( &self->atomList ); if (err) goto bail;
 	self->createFromInputStream = (cisfunc) createFromInputStream;
 	self->destroy             = destroy;
@@ -165,5 +166,5 @@ bail:
 	return err;
 }
 
-#endif
+
 

--- a/IsoLib/libisomediafile/src/SchemeTypeAtom.c
+++ b/IsoLib/libisomediafile/src/SchemeTypeAtom.c
@@ -1,3 +1,36 @@
+/*
+ *This software module was originally developed by InterDigital, Inc.
+ * in the course of development of MPEG-4.
+ * This software module is an implementation of a part of one or
+ * more MPEG-4 tools as specified by MPEG-4.
+ * ISO/IEC gives users of MPEG-4 free license to this
+ * software module or modifications thereof for use in hardware
+ * or software products claiming conformance to MPEG-4 only for evaluation and testing purposes.
+ * Those intending to use this software module in hardware or software
+ * products are advised that its use may infringe existing patents.
+ * The original developer of this software module and his/her company,
+ * the subsequent editors and their companies, and ISO/IEC have no
+ * liability for use of this software module or modifications thereof
+ * in an implementation.
+ *
+ * Copyright is not released for non MPEG-4 conforming
+ * products. InterDigital, Inc. retains full right to use the code for its own
+ * purpose, assign or donate the code to a third party and to
+ * inhibit third parties from using the code for non
+ * MPEG-4 conforming products.
+ *
+ * This copyright notice must be included in all copies or
+ * derivative works.
+ */
+
+
+/**
+ * @file SchemeTypeAtom.c
+ * @author Ahmed Hamza <Ahmed.Hamza@InterDigital.com>
+ * @date January 19, 2018
+ * @brief Implements functions for reading and writing SchemeTypeAtom instances.
+ */
+
 
 #include "MP4Atoms.h"
 #include <stdlib.h>
@@ -13,7 +46,7 @@ static void destroy(MP4AtomPtr s)
 	if (self == NULL)
 		BAILWITHERROR(MP4BadParamErr);
 
-		// if there is a scheme_url field, free it
+	// if there is a scheme_url field, free it
 	if (self->scheme_url) {
 		free(self->scheme_url);
 		self->scheme_url = NULL;

--- a/IsoLib/libisomediafile/src/SchemeTypeAtom.c
+++ b/IsoLib/libisomediafile/src/SchemeTypeAtom.c
@@ -11,7 +11,7 @@ static void destroy(MP4AtomPtr s)
 	err = MP4NoErr;
 
 	if (self == NULL)
-		BAILWITHERROR(MP4BadParamErr)
+		BAILWITHERROR(MP4BadParamErr);
 
 		// if there is a scheme_url field, free it
 	if (self->scheme_url) {
@@ -123,7 +123,7 @@ MP4Err MP4CreateSchemeTypeAtom(MP4SchemeTypeAtomPtr *outAtom)
 	err = MP4CreateFullAtom((MP4AtomPtr)self);
 	if (err) goto bail;
 	self->type = MP4SchemeTypeAtomType;
-	self->name = "SchemeType";
+	self->name = "SchemeTypeBox";
 	self->createFromInputStream = (cisfunc)createFromInputStream;
 	self->destroy = destroy;
 	self->calculateSize = calculateSize;

--- a/IsoLib/libisomediafile/src/SchemeTypeAtom.c
+++ b/IsoLib/libisomediafile/src/SchemeTypeAtom.c
@@ -1,0 +1,138 @@
+
+#include "MP4Atoms.h"
+#include <stdlib.h>
+#include <string.h>
+
+
+static void destroy(MP4AtomPtr s)
+{
+	MP4Err err;
+	MP4SchemeTypeAtomPtr self = (MP4SchemeTypeAtomPtr)s;
+	err = MP4NoErr;
+
+	if (self == NULL)
+		BAILWITHERROR(MP4BadParamErr)
+
+		// if there is a scheme_url field, free it
+	if (self->scheme_url) {
+		free(self->scheme_url);
+		self->scheme_url = NULL;
+	}
+
+	if (self->super)
+		self->super->destroy(s);
+bail:
+	TEST_RETURN(err);
+
+	return;
+}
+
+static MP4Err serialize(struct MP4Atom* s, char* buffer)
+{
+	MP4Err err;
+	MP4SchemeTypeAtomPtr self = (MP4SchemeTypeAtomPtr)s;
+	err = MP4NoErr;
+
+	err = MP4SerializeCommonFullAtomFields((MP4FullAtomPtr)s, buffer); if (err) goto bail;
+	buffer += self->bytesWritten;
+	PUT32(scheme_type);
+	PUT32(scheme_version);
+	if ((self->flags & 1) == 1)
+	{
+		u32 len = strlen(self->scheme_url) + 1;
+		PUTBYTES(self->scheme_url, len);
+	}
+
+	assert(self->bytesWritten == self->size);
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err calculateSize(struct MP4Atom* s)
+{
+	MP4Err err;
+	MP4SchemeTypeAtomPtr self = (MP4SchemeTypeAtomPtr)s;
+	err = MP4NoErr;
+
+	err = MP4CalculateFullAtomFieldSize((MP4FullAtomPtr)s); if (err) goto bail;
+	self->size += 8;  // 4 bytes (scheme_type) + 4 bytes (scheme_version)
+	if ((self->scheme_url) && (strlen(self->scheme_url) > 0))
+	{
+		self->flags = 1;
+		self->size += 1 + strlen(self->scheme_url); // strlen ignores \0
+	}
+	else self->flags = 0;
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStreamPtr inputStream)
+{
+	MP4Err err;
+	long bytesToRead;
+	char debugstr[256];
+	MP4SchemeTypeAtomPtr self = (MP4SchemeTypeAtomPtr)s;
+
+	err = MP4NoErr;
+	if (self == NULL)	BAILWITHERROR(MP4BadParamErr)
+		err = self->super->createFromInputStream(s, proto, (char*)inputStream); if (err) goto bail;
+	GET32(scheme_type);
+	GET32(scheme_version);
+	bytesToRead = self->size - self->bytesRead;
+	if (bytesToRead < 0)
+		BAILWITHERROR(MP4BadDataErr)
+	if (bytesToRead > 0)
+	{
+		if ((self->flags & 1) != 1) { err = MP4BadDataErr; goto bail; }
+		self->scheme_url = (char*)calloc(1, bytesToRead);
+		if (self->scheme_url == NULL)
+			BAILWITHERROR(MP4NoMemoryErr)
+			GETBYTES(bytesToRead, scheme_url);
+		if (bytesToRead < 200)
+		{
+			sprintf(debugstr, "Scheme URL location is \"%s\"", self->scheme_url);
+			DEBUG_MSG(debugstr);
+		}
+	}
+	else
+	{
+		if ((self->flags & 1) != 0) { err = MP4BadDataErr; goto bail; }
+	}
+
+	assert(self->bytesRead == self->size);
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+MP4Err MP4CreateSchemeTypeAtom(MP4SchemeTypeAtomPtr *outAtom)
+{
+	MP4Err err;
+	MP4SchemeTypeAtomPtr self;
+
+	self = (MP4SchemeTypeAtomPtr)calloc(1, sizeof(MP4SchemeTypeAtom));
+	TESTMALLOC(self);
+
+	err = MP4CreateFullAtom((MP4AtomPtr)self);
+	if (err) goto bail;
+	self->type = MP4SchemeTypeAtomType;
+	self->name = "SchemeType";
+	self->createFromInputStream = (cisfunc)createFromInputStream;
+	self->destroy = destroy;
+	self->calculateSize = calculateSize;
+	self->serialize = serialize;
+
+	*outAtom = self;
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+

--- a/IsoLib/libisomediafile/src/SchemeTypeAtom.c
+++ b/IsoLib/libisomediafile/src/SchemeTypeAtom.c
@@ -46,7 +46,7 @@ static void destroy(MP4AtomPtr s)
 	if (self == NULL)
 		BAILWITHERROR(MP4BadParamErr);
 
-	// if there is a scheme_url field, free it
+	/* if there is a scheme_url field, free it */
 	if (self->scheme_url) {
 		free(self->scheme_url);
 		self->scheme_url = NULL;
@@ -90,11 +90,11 @@ static MP4Err calculateSize(struct MP4Atom* s)
 	err = MP4NoErr;
 
 	err = MP4CalculateFullAtomFieldSize((MP4FullAtomPtr)s); if (err) goto bail;
-	self->size += 8;  // 4 bytes (scheme_type) + 4 bytes (scheme_version)
+	self->size += 8;  /* 4 bytes (scheme_type) + 4 bytes (scheme_version) */
 	if ((self->scheme_url) && (strlen(self->scheme_url) > 0))
 	{
 		self->flags = 1;
-		self->size += 1 + strlen(self->scheme_url); // strlen ignores \0
+		self->size += 1 + strlen(self->scheme_url); /* strlen ignores \0 */
 	}
 	else self->flags = 0;
 

--- a/IsoLib/libisomediafile/src/SecurityInfoAtom.c
+++ b/IsoLib/libisomediafile/src/SecurityInfoAtom.c
@@ -44,10 +44,10 @@ static void destroy( MP4AtomPtr s )
 		self->MP4OriginalFormat->destroy( self->MP4OriginalFormat );
 		self->MP4OriginalFormat = NULL;
 	}
-	if ( self->MP4SecurityScheme )
+	if ( self->MP4SchemeType )
 	{
-		self->MP4SecurityScheme->destroy( self->MP4SecurityScheme );
-		self->MP4SecurityScheme = NULL;
+		self->MP4SchemeType->destroy( self->MP4SchemeType );
+		self->MP4SchemeType = NULL;
 	}
 	if ( self->MP4SchemeInfo )
 	{
@@ -75,7 +75,7 @@ static MP4Err serialize( struct MP4Atom* s, char* buffer )
     /* PUT32_V( 0 );	*/	/* version/flags */
     
 	SERIALIZE_ATOM( MP4OriginalFormat );
-	SERIALIZE_ATOM( MP4SecurityScheme );
+	SERIALIZE_ATOM( MP4SchemeType );
 	SERIALIZE_ATOM( MP4SchemeInfo );
 
 	assert( self->bytesWritten == self->size );
@@ -94,7 +94,7 @@ static MP4Err calculateSize( struct MP4Atom* s )
 	err = MP4CalculateBaseAtomFieldSize( s ); if (err) goto bail;
 	self->size += 0;		/* version/flags */
 	ADD_ATOM_SIZE( MP4OriginalFormat );
-	ADD_ATOM_SIZE( MP4SecurityScheme );
+	ADD_ATOM_SIZE( MP4SchemeType );
 	ADD_ATOM_SIZE( MP4SchemeInfo );
 bail:
 	TEST_RETURN( err );
@@ -116,7 +116,7 @@ static MP4Err addAtom( MP4SecurityInfoAtomPtr self, MP4AtomPtr atom )
 	switch( atom->type )
 	{
 		ADDCASE( MP4OriginalFormat );
-		ADDCASE( MP4SecurityScheme );
+		ADDCASE( MP4SchemeType );
 		ADDCASE( MP4SchemeInfo );
 		/* todo: this default is wrong; we should be tolerant and accept unknown atoms */
 		default:

--- a/IsoLib/libisomediafile/src/SecuritySchemeAtom.c
+++ b/IsoLib/libisomediafile/src/SecuritySchemeAtom.c
@@ -24,6 +24,7 @@ derivative works. Copyright (c) 1999.
 	$Id: SecuritySchemeAtom.c,v 1.1.1.1 2002/09/20 08:53:34 julien Exp $
 */
 
+/*
 #include "MP4Atoms.h"
 #include <stdlib.h>
 #include <string.h>
@@ -147,7 +148,7 @@ MP4Err MP4CreateSecuritySchemeAtom( MP4SecuritySchemeAtomPtr *outAtom )
 
 	err = MP4CreateFullAtom( (MP4AtomPtr) self );
 	if ( err ) goto bail;
-	self->type = MP4SecuritySchemeAtomType;
+	self->type = MP4SchemeTypeAtomType;
 	self->name                = "SecurityScheme";
 	self->createFromInputStream = (cisfunc) createFromInputStream;
 	self->destroy             = destroy;
@@ -162,3 +163,4 @@ bail:
 }
 
 #endif
+*/

--- a/IsoLib/libisomediafile/src/StereoVideoAtom.c
+++ b/IsoLib/libisomediafile/src/StereoVideoAtom.c
@@ -1,0 +1,123 @@
+#include "MP4Atoms.h"
+#include <stdlib.h>
+
+
+static void destroy(MP4AtomPtr s)
+{
+	MP4Err err;
+	MP4StereoVideoAtomPtr self;
+
+	self = (MP4StereoVideoAtomPtr)s;
+	if (self == NULL) BAILWITHERROR(MP4BadParamErr)
+		DESTROY_ATOM_LIST_F(atomList);
+
+	if (self->super)
+		self->super->destroy(s);
+
+bail:
+	TEST_RETURN(err);
+
+	return;
+}
+
+
+static MP4Err addAtom(MP4StereoVideoAtomPtr self, MP4AtomPtr atom)
+{
+	MP4Err err;
+	err = MP4NoErr;
+
+	if (self == 0)
+		BAILWITHERROR(MP4BadParamErr);
+
+	err = MP4AddListEntry(atom, self->atomList); if (err) goto bail;
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static MP4Err serialize(struct MP4Atom* s, char* buffer)
+{
+	MP4Err err;
+	u32 tmp32;
+	u8 tmp8;
+	u32 i;
+	MP4StereoVideoAtomPtr self = (MP4StereoVideoAtomPtr)s;
+	err = MP4NoErr;
+
+	if (self->size > 0) {
+
+		err = MP4SerializeCommonBaseAtomFields(s, buffer); if (err) goto bail;
+		buffer += self->bytesWritten;
+
+		tmp32 = (self->reserved << 2) + self->single_view_allowed;
+		PUT32_V(tmp32);
+		PUT32(stereo_scheme);
+		PUT32(length);
+		
+		for (i = 0; i < self->length; i++) {
+			tmp8 = self->stereo_indication_type[i];
+			PUT8_V(tmp8);
+		}
+
+		SERIALIZE_ATOM_LIST(atomList);
+
+		assert(self->bytesWritten == self->size);
+
+	}
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+
+static MP4Err calculateSize(struct MP4Atom* s)
+{
+	MP4Err err;
+	MP4StereoVideoAtomPtr self = (MP4StereoVideoAtomPtr)s;
+	err = MP4NoErr;
+
+	err = MP4CalculateFullAtomFieldSize((MP4FullAtomPtr)s); if (err) goto bail;
+
+	self->size += (3 * 4) + self->length;
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+
+static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStreamPtr inputStream)
+{
+	MP4Err err;
+	u32 i;
+	u32 tmp32;
+
+	MP4StereoVideoAtomPtr self = (MP4StereoVideoAtomPtr)s;
+
+	err = MP4NoErr;
+	if (self == NULL)	
+		BAILWITHERROR(MP4BadParamErr);
+		
+	err = self->super->createFromInputStream(s, proto, (char*)inputStream);
+
+	GET32_V(tmp32);
+	self->reserved = (tmp32 >> 2) & 0x3FFF;
+	self->stereo_indication_type = (u8)(tmp32 & 0x3);
+	GET32(stereo_scheme);
+	GET32(length);
+	self->stereo_indication_type = calloc(self->length, sizeof(u8));
+	for (i = 0; i < self->length; i++) {
+		GET8_V(self->stereo_indication_type[i]);
+	}
+
+	assert(self->bytesRead == self->size);
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}

--- a/IsoLib/libisomediafile/src/StereoVideoAtom.c
+++ b/IsoLib/libisomediafile/src/StereoVideoAtom.c
@@ -1,3 +1,36 @@
+/*
+*This software module was originally developed by InterDigital, Inc.
+* in the course of development of MPEG-4.
+* This software module is an implementation of a part of one or
+* more MPEG-4 tools as specified by MPEG-4.
+* ISO/IEC gives users of MPEG-4 free license to this
+* software module or modifications thereof for use in hardware
+* or software products claiming conformance to MPEG-4 only for evaluation and testing purposes.
+* Those intending to use this software module in hardware or software
+* products are advised that its use may infringe existing patents.
+* The original developer of this software module and his/her company,
+* the subsequent editors and their companies, and ISO/IEC have no
+* liability for use of this software module or modifications thereof
+* in an implementation.
+*
+* Copyright is not released for non MPEG-4 conforming
+* products. InterDigital, Inc. retains full right to use the code for its own
+* purpose, assign or donate the code to a third party and to
+* inhibit third parties from using the code for non
+* MPEG-4 conforming products.
+*
+* This copyright notice must be included in all copies or
+* derivative works.
+*/
+
+/**
+ * @file StereoVideoAtom.c
+ * @author Ahmed Hamza <Ahmed.Hamza@InterDigital.com>
+ * @date January 19, 2018
+ * @brief Implements functions for reading and writing StereoVideoAtom instances.
+ */
+
+
 #include "MP4Atoms.h"
 #include <stdlib.h>
 
@@ -50,7 +83,7 @@ static MP4Err serialize(struct MP4Atom* s, char* buffer)
 
 	if (self->size > 0) {
 
-		err = MP4SerializeCommonBaseAtomFields(s, buffer); if (err) goto bail;
+		err = MP4SerializeCommonFullAtomFields((MP4FullAtomPtr)self, buffer); if (err) goto bail;
 		buffer += self->bytesWritten;
 
 		tmp32 = (self->reserved << 2) + self->single_view_allowed;

--- a/IsoLib/libisomediafile/src/StereoVideoAtom.c
+++ b/IsoLib/libisomediafile/src/StereoVideoAtom.c
@@ -135,16 +135,20 @@ MP4Err MP4CreateStereoVideoAtom(MP4StereoVideoAtomPtr *outAtom)
 	
 	err = MP4CreateFullAtom((MP4AtomPtr)self); if (err) goto bail;
 	
-	self->type = MP4StereoVideoAtomType;
-	self->name = "StereoVideoBox";
-	self->destroy = destroy;
-	self->createFromInputStream = (cisfunc)createFromInputStream;
-	self->calculateSize = calculateSize;
-	self->serialize = serialize;
-
-	self->addAtom = addAtom;
+	self->type						= MP4StereoVideoAtomType;
+	self->name						= "StereoVideoBox";
+	self->destroy					= destroy;
+	self->createFromInputStream		= (cisfunc)createFromInputStream;
+	self->calculateSize				= calculateSize;
+	self->serialize					= serialize;
+	self->addAtom					= addAtom;
 
 	err = MP4MakeLinkedList(&self->atomList); if (err) goto bail;
+
+	/*
+	self->stereo_indication_type = (u8*)calloc(1, sizeof(u8));
+	TESTMALLOC(self->stereo_indication_type);
+	*/
 
 	*outAtom = self;
 bail:

--- a/IsoLib/libisomediafile/src/StereoVideoGroupAtom.c
+++ b/IsoLib/libisomediafile/src/StereoVideoGroupAtom.c
@@ -1,0 +1,151 @@
+/*
+*This software module was originally developed by InterDigital, Inc.
+* in the course of development of MPEG-4.
+* This software module is an implementation of a part of one or
+* more MPEG-4 tools as specified by MPEG-4.
+* ISO/IEC gives users of MPEG-4 free license to this
+* software module or modifications thereof for use in hardware
+* or software products claiming conformance to MPEG-4 only for evaluation and testing purposes.
+* Those intending to use this software module in hardware or software
+* products are advised that its use may infringe existing patents.
+* The original developer of this software module and his/her company,
+* the subsequent editors and their companies, and ISO/IEC have no
+* liability for use of this software module or modifications thereof
+* in an implementation.
+*
+* Copyright is not released for non MPEG-4 conforming
+* products. InterDigital, Inc. retains full right to use the code for its own
+* purpose, assign or donate the code to a third party and to
+* inhibit third parties from using the code for non
+* MPEG-4 conforming products.
+*
+* This copyright notice must be included in all copies or
+* derivative works.
+*/
+
+/**
+* @file StereoVideoGroupAtom.c
+* @author Ahmed Hamza <Ahmed.Hamza@InterDigital.com>
+* @date January 19, 2018
+* @brief Implements functions for reading and writing StereoVideoAtom instances.
+*/
+
+
+#include "MP4Atoms.h"
+#include <stdlib.h>
+
+static void destroy(MP4AtomPtr s)
+{
+	MP4Err err;
+	MP4StereoVideoGroupAtomPtr self;
+
+	self = (MP4StereoVideoGroupAtomPtr)s;
+	if (self == NULL)
+		BAILWITHERROR(MP4BadParamErr);
+
+	if (self->super)
+		self->super->destroy(s);
+
+bail:
+	TEST_RETURN(err);
+
+	return;
+}
+
+
+static MP4Err serialize(struct MP4Atom* s, char* buffer)
+{
+	MP4Err err;
+	u32 tmp32;
+
+	MP4StereoVideoGroupAtomPtr self = (MP4StereoVideoGroupAtomPtr)s;
+	err = MP4NoErr;
+
+	if (self->size > 0) {
+
+		err = MP4SerializeCommonFullAtomFields((MP4FullAtomPtr)self, buffer); if (err) goto bail;
+		buffer += self->bytesWritten;
+		
+		PUT32(trackGroupID);
+
+		tmp32 = self->leftViewFlag << 31;
+		PUT32_V(tmp32);
+		
+		assert(self->bytesWritten == self->size);
+	}
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+
+static MP4Err calculateSize(struct MP4Atom* s)
+{
+	MP4Err err;
+
+	MP4StereoVideoGroupAtomPtr self = (MP4StereoVideoGroupAtomPtr)s;
+	err = MP4NoErr;
+
+	err = MP4CalculateFullAtomFieldSize((MP4FullAtomPtr)s); if (err) goto bail;
+
+	self->size += (2 * 4);
+
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+
+
+static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStreamPtr inputStream)
+{
+	MP4Err err;
+	u32 tmp32;
+
+	MP4StereoVideoGroupAtomPtr self = (MP4StereoVideoGroupAtomPtr)s;
+	err = MP4NoErr;
+
+	if (self == NULL)
+		BAILWITHERROR(MP4BadParamErr);
+
+	err = self->super->createFromInputStream(s, proto, (char*)inputStream);
+
+	GET32(trackGroupID);
+
+	GET32_V(tmp32);
+	self->leftViewFlag = (tmp32 >> 31) & 0x01;
+
+	assert(self->bytesRead == self->size);
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+
+MP4Err MP4CreateStereoVideoGroupAtom(MP4StereoVideoGroupAtomPtr *outAtom)
+{
+	MP4Err err;
+	MP4StereoVideoGroupAtomPtr self;
+
+	self = (MP4StereoVideoGroupAtomPtr)calloc(1, sizeof(MP4StereoVideoGroupAtom));
+	TESTMALLOC(self);
+
+	err = MP4CreateFullAtom((MP4AtomPtr)self); if (err) goto bail;
+
+	self->type = MP4StereoVideoGroupAtomType;
+	self->name = "StereoVideoGroupBox";
+	self->destroy = destroy;
+	self->createFromInputStream = (cisfunc)createFromInputStream;
+	self->calculateSize = calculateSize;
+	self->serialize = serialize;
+
+	*outAtom = self;
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}

--- a/IsoLib/libisomediafile/src/TrackTypeAtom.c
+++ b/IsoLib/libisomediafile/src/TrackTypeAtom.c
@@ -1,0 +1,215 @@
+
+#include "MP4Atoms.h"
+#include <stdlib.h>
+#include <string.h>
+
+// OMAF: TODO review code
+
+static void destroy(MP4AtomPtr s)
+{
+	MP4Err err;
+	MP4TrackTypeAtomPtr self;
+	u32 i;
+	err = MP4NoErr;
+	self = (MP4TrackTypeAtomPtr)s;
+	if (self == NULL)
+		BAILWITHERROR(MP4BadParamErr)
+
+	if (self->super)
+		self->super->destroy(s);
+bail:
+	TEST_RETURN(err);
+
+	return;
+}
+
+
+
+static ISOErr serialize(struct MP4Atom* s, char* buffer)
+{
+	ISOErr err;
+	u32 i;
+	MP4TrackTypeAtomPtr self = (MP4TrackTypeAtomPtr)s;
+
+	err = ISONoErr;
+
+	err = MP4SerializeCommonBaseAtomFields(s, buffer); if (err) goto bail;
+	buffer += self->bytesWritten;
+
+	PUT32(majorBrand);
+	PUT32(minorVersion);
+
+	for (i = 0; i < self->itemCount; i++)
+	{
+		PUT32_V((self->compatibilityList[i]));
+	}
+
+	assert(self->bytesWritten == self->size);
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static ISOErr calculateSize(struct MP4Atom* s)
+{
+	ISOErr err;
+	MP4TrackTypeAtomPtr self = (MP4TrackTypeAtomPtr)s;
+	err = ISONoErr;
+
+	err = MP4CalculateBaseAtomFieldSize(s); if (err) goto bail;
+	self->size += 2 * sizeof(u32);								/* brand and minorVersion */
+	self->size += self->itemCount * sizeof(u32);				/* compatibilityList */
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static ISOErr getBrand(struct MP4TrackTypeAtom *self, u32* standard, u32* minorversion)
+{
+	*standard = self->majorBrand;
+	*minorversion = self->minorVersion;
+
+	return MP4NoErr;
+}
+
+static u32 getStandard(struct MP4TrackTypeAtom *self, u32 standard)
+{
+	u32 i;
+	u32 outval;
+
+	outval = 0;
+
+	for (i = 0; i<self->itemCount; i++) {
+		if (self->compatibilityList[i] == standard) {
+			outval = standard;
+			break;
+		}
+	}
+	return outval;
+}
+
+/* add a track type to the compatibility list */
+static ISOErr addStandard(struct MP4TrackTypeAtom *self, u32 standard)
+{
+	ISOErr err;
+	err = ISONoErr;
+
+	if (!getStandard(self, standard)) {
+		self->itemCount++;
+		self->compatibilityList = (u32*)realloc(self->compatibilityList, self->itemCount * sizeof(u32));
+		TESTMALLOC(self->compatibilityList);
+		self->compatibilityList[self->itemCount - 1] = (u32)standard;
+	}
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+static ISOErr setBrand(struct MP4TrackTypeAtom *self, u32 standard, u32 minorversion)
+{
+	u32 oldstandard;
+	MP4Err err;
+	oldstandard = self->majorBrand;
+
+	self->majorBrand = standard;
+	self->minorVersion = minorversion;
+
+	/* in the compatibility list are also the new major brand, and the old one, if any */
+	if (oldstandard) { err = addStandard(self, oldstandard); if (err) return err; }
+	err = addStandard(self, standard);    if (err) return err;
+
+	return err;
+}
+
+static ISOErr createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStreamPtr inputStream)
+{
+	ISOErr err;
+	u32 items = 0;
+	long bytesToRead;
+	char typeString[8];
+	char msgString[80];
+	MP4TrackTypeAtomPtr self = (MP4TrackTypeAtomPtr)s;
+
+	err = ISONoErr;
+	if (self == NULL)
+		BAILWITHERROR(ISOBadParamErr)
+		err = self->super->createFromInputStream(s, proto, (char*)inputStream); if (err) goto bail;
+
+	GET32(majorBrand);
+	MP4TypeToString(self->majorBrand, typeString);
+	sprintf(msgString, " major brand is '%s'", typeString);
+	inputStream->msg(inputStream, msgString);
+
+	GET32(minorVersion);
+
+	bytesToRead = self->size - self->bytesRead;
+	if (bytesToRead < ((long) sizeof(u32)))							/* there must be at least one item in the compatibility list */
+		BAILWITHERROR(ISOBadDataErr)
+
+	if (self->compatibilityList)
+		free(self->compatibilityList);
+
+	self->compatibilityList = (u32 *)calloc(1, bytesToRead);
+	TESTMALLOC(self->compatibilityList);
+
+	while (bytesToRead > 0)
+	{
+		if (bytesToRead < ((long) sizeof(u32)))						/* we need to read a full u32 */
+			BAILWITHERROR(ISOBadDataErr)
+
+			GET32(compatibilityList[items]);
+		MP4TypeToString(self->compatibilityList[items], typeString);
+		sprintf(msgString, " minor brand is '%s'", typeString);
+		inputStream->msg(inputStream, msgString);
+		items++;
+		bytesToRead = self->size - self->bytesRead;
+	}
+
+	self->itemCount = items;
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}
+
+ISOErr MP4CreateTrackTypeAtom(MP4TrackTypeAtomPtr *outAtom)
+{
+	ISOErr err;
+	MP4TrackTypeAtomPtr self;
+
+	self = (MP4TrackTypeAtomPtr)calloc(1, sizeof(MP4TrackTypeAtom));
+	TESTMALLOC(self);
+
+	err = MP4CreateBaseAtom((MP4AtomPtr)self);
+	if (err) goto bail;
+
+	self->type = MP4TrackTypeAtomType;
+	self->name = "track type atom";
+	self->destroy = destroy;
+	self->createFromInputStream = (cisfunc)createFromInputStream;
+	self->calculateSize = calculateSize;
+	self->serialize = serialize;
+	self->addStandard = addStandard;
+	self->setBrand = setBrand;
+	self->getBrand = getBrand;
+	self->getStandard = getStandard;
+
+	self->majorBrand = 0; /* was ISOISOBrand */
+	self->minorVersion = (u32)0;
+	self->compatibilityList = (u32 *)calloc(1, sizeof(u32));
+	TESTMALLOC(self->compatibilityList);
+
+	/* self->compatibilityList[0]	= ISOISOBrand; */
+	/* self->compatibilityList[1]	= ISOISOBrand; */
+	/* No, MPEG-21 and meta movies are not ISOM branded */
+	self->itemCount = (u32)0;
+
+	*outAtom = self;
+bail:
+	TEST_RETURN(err);
+
+	return err;
+}

--- a/IsoLib/libisomediafile/src/TrackTypeAtom.c
+++ b/IsoLib/libisomediafile/src/TrackTypeAtom.c
@@ -72,7 +72,7 @@ static ISOErr serialize(struct MP4Atom* s, char* buffer)
 
 	err = ISONoErr;
 
-	err = MP4SerializeCommonFullAtomFields((MP4FullAtom*)s, buffer); if (err) goto bail;  // Full Atom
+	err = MP4SerializeCommonFullAtomFields((MP4FullAtom*)s, buffer); if (err) goto bail;  /* Full Atom */
 	buffer += self->bytesWritten;
 
 	PUT32(majorBrand);
@@ -96,7 +96,7 @@ static ISOErr calculateSize(struct MP4Atom* s)
 	MP4TrackTypeAtomPtr self = (MP4TrackTypeAtomPtr)s;
 	err = ISONoErr;
 
-	err = MP4CalculateFullAtomFieldSize((MP4FullAtomPtr)s); if (err) goto bail; // Full Atom
+	err = MP4CalculateFullAtomFieldSize((MP4FullAtomPtr)s); if (err) goto bail; /* Full Atom */
 	self->size += 2 * sizeof(u32);								/* brand and minorVersion */
 	self->size += self->itemCount * sizeof(u32);				/* compatibilityList */
 bail:
@@ -224,7 +224,7 @@ ISOErr MP4CreateTrackTypeAtom(MP4TrackTypeAtomPtr *outAtom)
 	self = (MP4TrackTypeAtomPtr)calloc(1, sizeof(MP4TrackTypeAtom));
 	TESTMALLOC(self);
 
-	err = MP4CreateFullAtom((MP4AtomPtr)self);  // Full atom
+	err = MP4CreateFullAtom((MP4AtomPtr)self);  /* Full atom */
 	if (err) goto bail;
 
 	self->type						= MP4TrackTypeAtomType;

--- a/IsoLib/libisomediafile/src/TrackTypeAtom.c
+++ b/IsoLib/libisomediafile/src/TrackTypeAtom.c
@@ -1,3 +1,36 @@
+/* 
+ * This software module was originally developed by InterDigital, Inc.
+ * in the course of development of MPEG-4.
+ * This software module is an implementation of a part of one or
+ * more MPEG-4 tools as specified by MPEG-4.
+ * ISO/IEC gives users of MPEG-4 free license to this
+ * software module or modifications thereof for use in hardware
+ * or software products claiming conformance to MPEG-4 only for evaluation and testing purposes.
+ * Those intending to use this software module in hardware or software
+ * products are advised that its use may infringe existing patents.
+ * The original developer of this software module and his/her company,
+ * the subsequent editors and their companies, and ISO/IEC have no
+ * liability for use of this software module or modifications thereof
+ * in an implementation.
+ *
+ * Copyright is not released for non MPEG-4 conforming
+ * products. InterDigital, Inc. retains full right to use the code for its own
+ * purpose, assign or donate the code to a third party and to
+ * inhibit third parties from using the code for non
+ * MPEG-4 conforming products.
+ *  
+ * This copyright notice must be included in all copies or
+ * derivative works. 
+ */
+
+
+/**
+ * @file TrackTypeAtom.c
+ * @author Ahmed Hamza <Ahmed.Hamza@InterDigital.com>
+ * @date 
+ * @brief Implements functions for reading and writing TrackTypeAtom instances.
+ */
+
 
 #include "MP4Atoms.h"
 #include <stdlib.h>
@@ -8,7 +41,6 @@ static void destroy(MP4AtomPtr s)
 {
 	MP4Err err;
 	MP4TrackTypeAtomPtr self;
-	u32 i;
 
 	err = MP4NoErr;
 	self = (MP4TrackTypeAtomPtr)s;
@@ -40,7 +72,7 @@ static ISOErr serialize(struct MP4Atom* s, char* buffer)
 
 	err = ISONoErr;
 
-	err = MP4SerializeCommonFullAtomFields(s, buffer); if (err) goto bail;  // Full Atom
+	err = MP4SerializeCommonFullAtomFields((MP4FullAtom*)s, buffer); if (err) goto bail;  // Full Atom
 	buffer += self->bytesWritten;
 
 	PUT32(majorBrand);

--- a/IsoLib/libisomediafile/src/TrackTypeAtom.c
+++ b/IsoLib/libisomediafile/src/TrackTypeAtom.c
@@ -3,17 +3,24 @@
 #include <stdlib.h>
 #include <string.h>
 
-// OMAF: TODO review code
 
 static void destroy(MP4AtomPtr s)
 {
 	MP4Err err;
 	MP4TrackTypeAtomPtr self;
 	u32 i;
+
 	err = MP4NoErr;
 	self = (MP4TrackTypeAtomPtr)s;
+	
 	if (self == NULL)
-		BAILWITHERROR(MP4BadParamErr)
+		BAILWITHERROR(MP4BadParamErr);
+
+	if (self->compatibilityList)
+	{
+		free(self->compatibilityList);
+		self->compatibilityList = NULL;
+	}
 
 	if (self->super)
 		self->super->destroy(s);
@@ -33,7 +40,7 @@ static ISOErr serialize(struct MP4Atom* s, char* buffer)
 
 	err = ISONoErr;
 
-	err = MP4SerializeCommonBaseAtomFields(s, buffer); if (err) goto bail;
+	err = MP4SerializeCommonFullAtomFields(s, buffer); if (err) goto bail;  // Full Atom
 	buffer += self->bytesWritten;
 
 	PUT32(majorBrand);
@@ -57,7 +64,7 @@ static ISOErr calculateSize(struct MP4Atom* s)
 	MP4TrackTypeAtomPtr self = (MP4TrackTypeAtomPtr)s;
 	err = ISONoErr;
 
-	err = MP4CalculateBaseAtomFieldSize(s); if (err) goto bail;
+	err = MP4CalculateFullAtomFieldSize((MP4FullAtomPtr)s); if (err) goto bail; // Full Atom
 	self->size += 2 * sizeof(u32);								/* brand and minorVersion */
 	self->size += self->itemCount * sizeof(u32);				/* compatibilityList */
 bail:
@@ -131,12 +138,14 @@ static ISOErr createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
 	long bytesToRead;
 	char typeString[8];
 	char msgString[80];
+
 	MP4TrackTypeAtomPtr self = (MP4TrackTypeAtomPtr)s;
 
 	err = ISONoErr;
 	if (self == NULL)
-		BAILWITHERROR(ISOBadParamErr)
-		err = self->super->createFromInputStream(s, proto, (char*)inputStream); if (err) goto bail;
+		BAILWITHERROR(ISOBadParamErr);
+		
+	err = self->super->createFromInputStream(s, proto, (char*)inputStream); if (err) goto bail;
 
 	GET32(majorBrand);
 	MP4TypeToString(self->majorBrand, typeString);
@@ -147,7 +156,7 @@ static ISOErr createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
 
 	bytesToRead = self->size - self->bytesRead;
 	if (bytesToRead < ((long) sizeof(u32)))							/* there must be at least one item in the compatibility list */
-		BAILWITHERROR(ISOBadDataErr)
+		BAILWITHERROR(ISOBadDataErr);
 
 	if (self->compatibilityList)
 		free(self->compatibilityList);
@@ -158,9 +167,9 @@ static ISOErr createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
 	while (bytesToRead > 0)
 	{
 		if (bytesToRead < ((long) sizeof(u32)))						/* we need to read a full u32 */
-			BAILWITHERROR(ISOBadDataErr)
+			BAILWITHERROR(ISOBadDataErr);
 
-			GET32(compatibilityList[items]);
+		GET32(compatibilityList[items]);
 		MP4TypeToString(self->compatibilityList[items], typeString);
 		sprintf(msgString, " minor brand is '%s'", typeString);
 		inputStream->msg(inputStream, msgString);
@@ -183,11 +192,11 @@ ISOErr MP4CreateTrackTypeAtom(MP4TrackTypeAtomPtr *outAtom)
 	self = (MP4TrackTypeAtomPtr)calloc(1, sizeof(MP4TrackTypeAtom));
 	TESTMALLOC(self);
 
-	err = MP4CreateBaseAtom((MP4AtomPtr)self);
+	err = MP4CreateFullAtom((MP4AtomPtr)self);  // Full atom
 	if (err) goto bail;
 
 	self->type = MP4TrackTypeAtomType;
-	self->name = "track type atom";
+	self->name = "TrackTypeBox";
 	self->destroy = destroy;
 	self->createFromInputStream = (cisfunc)createFromInputStream;
 	self->calculateSize = calculateSize;
@@ -199,7 +208,7 @@ ISOErr MP4CreateTrackTypeAtom(MP4TrackTypeAtomPtr *outAtom)
 
 	self->majorBrand = 0; /* was ISOISOBrand */
 	self->minorVersion = (u32)0;
-	self->compatibilityList = (u32 *)calloc(1, sizeof(u32));
+	self->compatibilityList = (u32*)calloc(1, sizeof(u32));
 	TESTMALLOC(self->compatibilityList);
 
 	/* self->compatibilityList[0]	= ISOISOBrand; */

--- a/IsoLib/libisomediafile/src/TrackTypeAtom.c
+++ b/IsoLib/libisomediafile/src/TrackTypeAtom.c
@@ -195,20 +195,21 @@ ISOErr MP4CreateTrackTypeAtom(MP4TrackTypeAtomPtr *outAtom)
 	err = MP4CreateFullAtom((MP4AtomPtr)self);  // Full atom
 	if (err) goto bail;
 
-	self->type = MP4TrackTypeAtomType;
-	self->name = "TrackTypeBox";
-	self->destroy = destroy;
-	self->createFromInputStream = (cisfunc)createFromInputStream;
-	self->calculateSize = calculateSize;
-	self->serialize = serialize;
-	self->addStandard = addStandard;
-	self->setBrand = setBrand;
-	self->getBrand = getBrand;
-	self->getStandard = getStandard;
+	self->type						= MP4TrackTypeAtomType;
+	self->name						= "TrackTypeBox";
+	self->destroy					= destroy;
+	self->createFromInputStream		= (cisfunc)createFromInputStream;
+	self->calculateSize				= calculateSize;
+	self->serialize					= serialize;
+	self->addStandard				= addStandard;
+	self->setBrand					= setBrand;
+	self->getBrand					= getBrand;
+	self->getStandard				= getStandard;
 
-	self->majorBrand = 0; /* was ISOISOBrand */
-	self->minorVersion = (u32)0;
-	self->compatibilityList = (u32*)calloc(1, sizeof(u32));
+	self->majorBrand				= 0; /* was ISOISOBrand */
+	self->minorVersion				= (u32)0;
+
+	self->compatibilityList			= (u32*)calloc(1, sizeof(u32));	
 	TESTMALLOC(self->compatibilityList);
 
 	/* self->compatibilityList[0]	= ISOISOBrand; */

--- a/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj
+++ b/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj
@@ -271,6 +271,7 @@
     <ClCompile Include="..\..\src\SchemeTypeAtom.c" />
     <ClCompile Include="..\..\src\SingleItemTypeReferenceAtom.c" />
     <ClCompile Include="..\..\src\StereoVideoAtom.c" />
+    <ClCompile Include="..\..\src\StereoVideoGroupAtom.c" />
     <ClCompile Include="..\..\src\TrackExtensionPropertiesAtom.c" />
     <ClCompile Include="..\..\src\TrackFragmentDecodeTimeAtom.c" />
     <ClCompile Include="..\..\src\AudioSampleEntryAtom.c" />

--- a/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj
+++ b/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj
@@ -252,6 +252,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\src\AdditionalMetaDataContainerAtom.c" />
     <ClCompile Include="..\..\src\ChannelLayoutAtom.c" />
+    <ClCompile Include="..\..\src\CompatibleSchemeTypeAtom.c" />
     <ClCompile Include="..\..\src\CompositionToDecodeAtom.c" />
     <ClCompile Include="..\..\src\DownMixInstructionsAtom.c" />
     <ClCompile Include="..\..\src\ExtendedLanguageTag.c" />
@@ -263,8 +264,11 @@
     <ClCompile Include="..\..\src\LoudnessAtom.c" />
     <ClCompile Include="..\..\src\LoudnessBaseAtom.c" />
     <ClCompile Include="..\..\src\MetaboxRelationAtom.c" />
+    <ClCompile Include="..\..\src\RestrictedSchemeInfoAtom.c" />
+    <ClCompile Include="..\..\src\RestrictedVideoSampleEntry.c" />
     <ClCompile Include="..\..\src\SampleAuxiliaryInformationOffsetsAtom.c" />
     <ClCompile Include="..\..\src\SampleAuxiliaryInformationSizesAtom.c" />
+    <ClCompile Include="..\..\src\SchemeTypeAtom.c" />
     <ClCompile Include="..\..\src\SingleItemTypeReferenceAtom.c" />
     <ClCompile Include="..\..\src\TrackExtensionPropertiesAtom.c" />
     <ClCompile Include="..\..\src\TrackFragmentDecodeTimeAtom.c" />
@@ -372,6 +376,7 @@
     <ClCompile Include="..\..\src\TrackHeaderAtom.c" />
     <ClCompile Include="..\..\src\TrackReferenceAtom.c" />
     <ClCompile Include="..\..\src\TrackReferenceTypeAtom.c" />
+    <ClCompile Include="..\..\src\TrackTypeAtom.c" />
     <ClCompile Include="..\..\src\UnknownAtom.c" />
     <ClCompile Include="..\..\src\UserDataAtom.c" />
     <ClCompile Include="..\..\src\VideoMediaHeaderAtom.c" />

--- a/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj
+++ b/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj
@@ -270,6 +270,7 @@
     <ClCompile Include="..\..\src\SampleAuxiliaryInformationSizesAtom.c" />
     <ClCompile Include="..\..\src\SchemeTypeAtom.c" />
     <ClCompile Include="..\..\src\SingleItemTypeReferenceAtom.c" />
+    <ClCompile Include="..\..\src\StereoVideoAtom.c" />
     <ClCompile Include="..\..\src\TrackExtensionPropertiesAtom.c" />
     <ClCompile Include="..\..\src\TrackFragmentDecodeTimeAtom.c" />
     <ClCompile Include="..\..\src\AudioSampleEntryAtom.c" />

--- a/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj.filters
+++ b/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj.filters
@@ -488,6 +488,9 @@
     <ClCompile Include="..\..\src\StereoVideoAtom.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\StereoVideoGroupAtom.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\FileMappingDataHandler.h">

--- a/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj.filters
+++ b/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj.filters
@@ -470,6 +470,21 @@
     <ClCompile Include="..\..\src\ItemPropertyContainerAtom.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\RestrictedSchemeInfoAtom.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\RestrictedVideoSampleEntry.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\TrackTypeAtom.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\CompatibleSchemeTypeAtom.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\SchemeTypeAtom.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\FileMappingDataHandler.h">

--- a/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj.filters
+++ b/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.vcxproj.filters
@@ -485,6 +485,9 @@
     <ClCompile Include="..\..\src\SchemeTypeAtom.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\StereoVideoAtom.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\FileMappingDataHandler.h">

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,3 +1,8 @@
+Release notes Feb 2018
+
+a) Added new atoms defined in OMAF FDIS [N17235] as extensions to ISO/IEC 14496-12 and ISO/IEC 14496-15. 
+
+
 Release notes Jan 2018
 
 a) Added support for Visual Studio 2008 (required also fixing some minor compiler errors)

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,6 +2,7 @@ Release notes Feb 2018
 
 a) Added new atoms defined in OMAF FDIS [N17235] as extensions to ISO/IEC 14496-12 and ISO/IEC 14496-15. 
 
+b) Added Visual Studio 2013 solution and project files for hevc_extractors.
 
 Release notes Jan 2018
 


### PR DESCRIPTION
This request includes support for new atoms defined in OMAF FDIS as needed extensions to ISO/IEC 14496-12 and ISO/IEC 14496-15. Support for restricted schemes (which was already in ISO/IEC 14496-12 but not implemented in the reference software) was also added. Also added a Visual Studio solution for hevc_extractor code.

Please squash all commits into a single one when merging.