### PR TITLE
MPEG-D USAC and MPEG-H 3D Audio support / edit list handling

### DIFF
--- a/IsoLib/libisomediafile/linux/libisomediafile/Makefile
+++ b/IsoLib/libisomediafile/linux/libisomediafile/Makefile
@@ -12,6 +12,7 @@ sources = \
 	BaseDescriptor.c \
 	ChunkOffsetAtom.c \
 	ClockReferenceMediaHeader.c \
+	CompatibleSchemeTypeAtom.c \
 	CopyrightAtom.c \
 	DataEntryURLAtom.c \
 	DataEntryURNAtom.c \
@@ -85,15 +86,20 @@ sources = \
 	ObjectDescriptorAtom.c \
 	ObjectDescriptorMediaHeader.c \
 	QTMovies.c \
+	RestrictedSchemeInfoAtom.c \
+	RestrictedVideoSampleEntry.c \
 	SLConfigDescriptor.c \
 	SampleDescriptionAtom.c \
 	SampleSizeAtom.c \
 	SampleTableAtom.c \
 	SampleToChunkAtom.c \
 	SceneDescriptionMediaHeader.c \
+	SchemeTypeAtom.c \
 	ShadowSyncAtom.c \
 	SimpleFileMappingObject.c \
 	SoundMediaHeaderAtom.c \
+	StereoVideoAtom.c \
+	StereoVideoGroupAtom.c \
 	SubSampleInformationAtom.c \
 	SyncSampleAtom.c \
 	TimeToSampleAtom.c \
@@ -101,6 +107,7 @@ sources = \
 	TrackHeaderAtom.c \
 	TrackReferenceAtom.c \
 	TrackReferenceTypeAtom.c \
+	TrackTypeAtom.c \
 	TrackGroupAtom.c \
 	TrackGroupTypeAtom.c \
 	UnknownAtom.c \
@@ -160,15 +167,8 @@ sources = \
 	SingleItemTypeReferenceAtom.c \
 	ItemPropertiesAtom.c \
 	ItemPropertyAssociationAtom.c \
-	ItemPropertyContainerAtom.c \
-	SchemeTypeAtom.c \
-	CompatibleSchemeTypeAtom.c \
-	RestrictedSchemeInfoAtom.c \
-	StereoVideoAtom.c \
-	StereoVideoGroupAtom.c \
-	TrackTypeAtom.c \
-	RestrictedVideoSampleEntry.c
-	
+	ItemPropertyContainerAtom.c
+
 
 
 

--- a/IsoLib/libisomediafile/macosx/libisomediafile/Makefile
+++ b/IsoLib/libisomediafile/macosx/libisomediafile/Makefile
@@ -12,6 +12,7 @@ sources = \
 	BaseDescriptor.c \
 	ChunkOffsetAtom.c \
 	ClockReferenceMediaHeader.c \
+	CompatibleSchemeTypeAtom.c \
 	CopyrightAtom.c \
 	DataEntryURLAtom.c \
 	DataEntryURNAtom.c \
@@ -85,15 +86,20 @@ sources = \
 	ObjectDescriptorAtom.c \
 	ObjectDescriptorMediaHeader.c \
 	QTMovies.c \
+	RestrictedSchemeInfoAtom.c \
+	RestrictedVideoSampleEntry.c \
 	SLConfigDescriptor.c \
 	SampleDescriptionAtom.c \
 	SampleSizeAtom.c \
 	SampleTableAtom.c \
 	SampleToChunkAtom.c \
 	SceneDescriptionMediaHeader.c \
+	SchemeTypeAtom.c \
 	ShadowSyncAtom.c \
 	SimpleFileMappingObject.c \
 	SoundMediaHeaderAtom.c \
+	StereoVideoAtom.c \
+	StereoVideoGroupAtom.c \
 	SubSampleInformationAtom.c \
 	SyncSampleAtom.c \
 	TimeToSampleAtom.c \
@@ -101,6 +107,7 @@ sources = \
 	TrackHeaderAtom.c \
 	TrackReferenceAtom.c \
 	TrackReferenceTypeAtom.c \
+	TrackTypeAtom.c \
 	TrackGroupAtom.c \
 	TrackGroupTypeAtom.c \
 	UnknownAtom.c \
@@ -160,13 +167,7 @@ sources = \
 	SingleItemTypeReferenceAtom.c \
 	ItemPropertiesAtom.c \
 	ItemPropertyAssociationAtom.c \
-	ItemPropertyContainerAtom.c \
-	SchemeTypeAtom.c \
-	CompatibleSchemeTypeAtom.c \
-	RestrictedSchemeInfoAtom.c \
-	StereoVideoAtom.c \
-	TrackTypeAtom.c \
-	RestrictedVideoSampleEntry.c
+	ItemPropertyContainerAtom.c
 
 
 

--- a/IsoLib/libisomediafile/w32/libisomediafile/VS2008/libisomedia.vcproj
+++ b/IsoLib/libisomediafile/w32/libisomediafile/VS2008/libisomedia.vcproj
@@ -664,6 +664,10 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="..\..\..\src\CompatibleSchemeTypeAtom.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\..\src\CompositionToDecodeAtom.c"
 				>
 			</File>
@@ -1805,6 +1809,126 @@
 			</File>
 			<File
 				RelativePath="..\..\..\src\ItemLocationAtom.c"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\..\..\src\ItemPropertiesAtom.c"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\..\..\src\ItemPropertyAssociationAtom.c"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\..\..\src\ItemPropertyContainerAtom.c"
 				>
 				<FileConfiguration
 					Name="Release|Win32"
@@ -4380,6 +4504,14 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="..\..\..\src\RestrictedSchemeInfoAtom.c"
+				>
+			</File>
+			<File
+				RelativePath="..\..\..\src\RestrictedVideoSampleEntry.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\..\src\SampleAuxiliaryInformationOffsetsAtom.c"
 				>
 			</File>
@@ -4748,6 +4880,10 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="..\..\..\src\SchemeTypeAtom.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\..\src\SecurityInfoAtom.c"
 				>
 				<FileConfiguration
@@ -4950,6 +5086,14 @@
 						PreprocessorDefinitions=""
 					/>
 				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\..\..\src\StereoVideoAtom.c"
+				>
+			</File>
+			<File
+				RelativePath="..\..\..\src\StereoVideoGroupAtom.c"
+				>
 			</File>
 			<File
 				RelativePath="..\..\..\src\SubSampleInformationAtom.c"
@@ -5412,6 +5556,10 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="..\..\..\src\TrackTypeAtom.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\..\src\UnknownAtom.c"
 				>
 				<FileConfiguration
@@ -5653,126 +5801,6 @@
 			</File>
 			<File
 				RelativePath="..\..\..\src\XMLMetaSampleEntry.c"
-				>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\..\..\src\ItemPropertiesAtom.c"
-				>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\..\..\src\ItemPropertyAssociationAtom.c"
-				>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\..\..\src\ItemPropertyContainerAtom.c"
 				>
 				<FileConfiguration
 					Name="Release|Win32"

--- a/IsoLib/libisomediafile/w32/libisomediafile/VS2012/libisomedia.vcxproj
+++ b/IsoLib/libisomediafile/w32/libisomediafile/VS2012/libisomedia.vcxproj
@@ -257,6 +257,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\..\src\AdditionalMetaDataContainerAtom.c" />
     <ClCompile Include="..\..\..\src\ChannelLayoutAtom.c" />
+    <ClCompile Include="..\..\..\src\CompatibleSchemeTypeAtom.c" />
     <ClCompile Include="..\..\..\src\CompositionToDecodeAtom.c" />
     <ClCompile Include="..\..\..\src\DownMixInstructionsAtom.c" />
     <ClCompile Include="..\..\..\src\ExtendedLanguageTag.c" />
@@ -268,9 +269,14 @@
     <ClCompile Include="..\..\..\src\LoudnessAtom.c" />
     <ClCompile Include="..\..\..\src\LoudnessBaseAtom.c" />
     <ClCompile Include="..\..\..\src\MetaboxRelationAtom.c" />
+    <ClCompile Include="..\..\..\src\RestrictedSchemeInfoAtom.c" />
+    <ClCompile Include="..\..\..\src\RestrictedVideoSampleEntry.c" />
     <ClCompile Include="..\..\..\src\SampleAuxiliaryInformationOffsetsAtom.c" />
     <ClCompile Include="..\..\..\src\SampleAuxiliaryInformationSizesAtom.c" />
+    <ClCompile Include="..\..\..\src\SchemeTypeAtom.c" />
     <ClCompile Include="..\..\..\src\SingleItemTypeReferenceAtom.c" />
+    <ClCompile Include="..\..\..\src\StereoVideoAtom.c" />
+    <ClCompile Include="..\..\..\src\StereoVideoGroupAtom.c" />
     <ClCompile Include="..\..\..\src\TrackExtensionPropertiesAtom.c" />
     <ClCompile Include="..\..\..\src\TrackFragmentDecodeTimeAtom.c" />
     <ClCompile Include="..\..\..\src\AudioSampleEntryAtom.c" />
@@ -377,6 +383,7 @@
     <ClCompile Include="..\..\..\src\TrackHeaderAtom.c" />
     <ClCompile Include="..\..\..\src\TrackReferenceAtom.c" />
     <ClCompile Include="..\..\..\src\TrackReferenceTypeAtom.c" />
+    <ClCompile Include="..\..\..\src\TrackTypeAtom.c" />
     <ClCompile Include="..\..\..\src\UnknownAtom.c" />
     <ClCompile Include="..\..\..\src\UserDataAtom.c" />
     <ClCompile Include="..\..\..\src\VideoMediaHeaderAtom.c" />

--- a/IsoLib/libisomediafile/w32/libisomediafile/VS2012/libisomedia.vcxproj.filters
+++ b/IsoLib/libisomediafile/w32/libisomediafile/VS2012/libisomedia.vcxproj.filters
@@ -164,6 +164,13 @@
     <ClCompile Include="..\..\..\src\AMRSpecificInfoAtom.c" />
     <ClCompile Include="..\..\..\src\H263SpecificInfoAtom.c" />
     <ClCompile Include="..\..\..\src\SampleDependencyAtom.c" />
+    <ClCompile Include="..\..\..\src\CompatibleSchemeTypeAtom.c" />
+    <ClCompile Include="..\..\..\src\RestrictedSchemeInfoAtom.c" />
+    <ClCompile Include="..\..\..\src\RestrictedVideoSampleEntry.c" />
+    <ClCompile Include="..\..\..\src\SchemeTypeAtom.c" />
+    <ClCompile Include="..\..\..\src\StereoVideoAtom.c" />
+    <ClCompile Include="..\..\..\src\StereoVideoGroupAtom.c" />
+    <ClCompile Include="..\..\..\src\TrackTypeAtom.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\FileMappingDataHandler.h" />


### PR DESCRIPTION
I solved some issues with the integration of the libisomediafile into the reference software of MPEG-D USAC and MPEG-H 3D Audio: I added missing source code files to Visual Studio 2008 and Visual Studio 2012 project files.
Additionally I solved a bug when writing the edit list. In case the trackStartTime equals 0 the elst should be written when the media duration equals the track duration.