### PR TITLE
Fix bug when adding scheme info to a 'resv' atom.

### DIFF
--- a/IsoLib/libisomediafile/src/GenericSampleEntryAtom.c
+++ b/IsoLib/libisomediafile/src/GenericSampleEntryAtom.c
@@ -98,10 +98,15 @@ static MP4Err createFromInputStream( MP4AtomPtr s, MP4AtomPtr proto, MP4InputStr
 
 	GETBYTES( 6, reserved );
 	GET16( dataReferenceIndex );
-	self->dataSize = self->size - self->bytesRead;
+	self->dataSize = self->size - self->bytesRead;  // NOTE: this will prevent the extention atoms list from being read
 	self->data = (char*) malloc( self->dataSize );
 	TESTMALLOC( self->data );
 	GETBYTES( self->dataSize, data );
+	GETATOM_LIST(ExtensionAtomList); //
+
+	if (self->bytesRead != self->size)
+		BAILWITHERROR(MP4BadDataErr);
+
 bail:
 	TEST_RETURN( err );
 

--- a/IsoLib/libisomediafile/src/GenericSampleEntryAtom.c
+++ b/IsoLib/libisomediafile/src/GenericSampleEntryAtom.c
@@ -98,11 +98,11 @@ static MP4Err createFromInputStream( MP4AtomPtr s, MP4AtomPtr proto, MP4InputStr
 
 	GETBYTES( 6, reserved );
 	GET16( dataReferenceIndex );
-	self->dataSize = self->size - self->bytesRead;  // NOTE: this will prevent the extention atoms list from being read
+	self->dataSize = self->size - self->bytesRead;  /* NOTE: this will prevent the extention atoms list from being read */
 	self->data = (char*) malloc( self->dataSize );
 	TESTMALLOC( self->data );
 	GETBYTES( self->dataSize, data );
-	GETATOM_LIST(ExtensionAtomList); //
+	GETATOM_LIST(ExtensionAtomList);
 
 	if (self->bytesRead != self->size)
 		BAILWITHERROR(MP4BadDataErr);

--- a/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
+++ b/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
@@ -47,12 +47,12 @@ MP4Err MP4ParseAtomUsingProtoList( MP4InputStreamPtr inputStream, u32* protoList
 		u32 MP4SampleEntryProtos[] = { MP4MPEGSampleEntryAtomType, MP4VisualSampleEntryAtomType, MP4AudioSampleEntryAtomType, 
 		MP4EncAudioSampleEntryAtomType, MP4EncVisualSampleEntryAtomType, 
 		MP4XMLMetaSampleEntryAtomType, MP4TextMetaSampleEntryAtomType, 
-		MP4AMRSampleEntryAtomType, MP4AWBSampleEntryAtomType, MP4AMRWPSampleEntryAtomType, MP4H263SampleEntryAtomType, 
+		MP4AMRSampleEntryAtomType, MP4AWBSampleEntryAtomType, MP4AMRWPSampleEntryAtomType, MP4H263SampleEntryAtomType, MP4RestrictedVideoSampleEntryAtomType, 
 		0 };
 #else
 		u32 MP4SampleEntryProtos[] = { MP4MPEGSampleEntryAtomType, MP4VisualSampleEntryAtomType, MP4AudioSampleEntryAtomType, 
 		MP4XMLMetaSampleEntryAtomType, MP4TextMetaSampleEntryAtomType, 
-		MP4AMRSampleEntryAtomType, MP4AWBSampleEntryAtomType, MP4AMRWPSampleEntryAtomType, MP4H263SampleEntryAtomType, 
+		MP4AMRSampleEntryAtomType, MP4AWBSampleEntryAtomType, MP4AMRWPSampleEntryAtomType, MP4H263SampleEntryAtomType, MP4RestrictedVideoSampleEntryAtomType,
 		0 };
 #endif
 

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -1468,6 +1468,8 @@ typedef struct MP4RestrictedVideoSampleEntryAtom {
 	MP4Err(*transform) (struct MP4Atom *self, u32 sch_type, u32 sch_version, char* sch_url);
 	MP4Err(*untransform) (struct MP4Atom *self);
 
+	MP4Err(*addAtom)(struct MP4RestrictedVideoSampleEntryAtom* self, MP4AtomPtr atom);
+
 	char		reserved1[6];
 	char		reserved2[16];		/* uint(32)[4] */
 	/* u32			reserved3;         uint(32) = 0x01400f0 */

--- a/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
+++ b/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
@@ -150,22 +150,6 @@ static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
 	GET16(reserved9);
 	GETATOM(MP4RestrictedSchemeInfo);
 	GETATOM_LIST(ExtensionAtomList);
-	//PARSE_ATOM_INCLUDES(MP4RestrictedVideoSampleEntryAtom);
-	/*
-	while (self->bytesRead < self->size)
-	{
-		MP4AtomPtr atom;
-		err = MP4ParseAtom((MP4InputStreamPtr)inputStream, &atom);
-		if (err) goto bail;
-		self->bytesRead += atom->size;
-		if (((atom->type) == MP4FreeSpaceAtomType) || ((atom->type) == MP4SkipAtomType))
-			atom->destroy(atom);
-		else {
-			err = addAtom(self, atom);
-			if (err) goto bail;
-		}
-	}
-	*/
 
 	if (self->bytesRead != self->size)
 		BAILWITHERROR(MP4BadDataErr);
@@ -211,9 +195,6 @@ static MP4Err transform(struct MP4Atom *s, u32 sch_type, u32 sch_version, char* 
 	err = MP4CreateRestrictedSchemeInfoAtom(&rinf); if (err) goto bail;
 
 	/* assign */
-	//rinf->MP4OriginalFormat = (MP4AtomPtr)frma; frma = NULL;
-	//rinf->MP4SchemeType = (MP4AtomPtr)schm; schm = NULL;
-	//rinf->MP4SchemeInfo = (MP4AtomPtr)schi; schi = NULL;
 	rinf->addAtom(rinf, (MP4AtomPtr)frma); frma = NULL;
 	rinf->addAtom(rinf, (MP4AtomPtr)schm); schm = NULL;
 	rinf->addAtom(rinf, (MP4AtomPtr)schi); schi = NULL;
@@ -221,7 +202,6 @@ static MP4Err transform(struct MP4Atom *s, u32 sch_type, u32 sch_version, char* 
 	self->type = self->restriction_type;
 
 	/* set */
-	//self->MP4RestrictedSchemeInfo = (MP4AtomPtr)rinf;
 	self->addAtom(self, (MP4AtomPtr)rinf);
 
 bail:

--- a/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
+++ b/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
@@ -206,14 +206,18 @@ static MP4Err transform(struct MP4Atom *s, u32 sch_type, u32 sch_version, char* 
 	err = MP4CreateRestrictedSchemeInfoAtom(&rinf); if (err) goto bail;
 
 	/* assign */
-	rinf->MP4OriginalFormat = (MP4AtomPtr)frma; frma = NULL;
-	rinf->MP4SchemeType = (MP4AtomPtr)schm; schm = NULL;
-	rinf->MP4SchemeInfo = (MP4AtomPtr)schi; schi = NULL;
+	//rinf->MP4OriginalFormat = (MP4AtomPtr)frma; frma = NULL;
+	//rinf->MP4SchemeType = (MP4AtomPtr)schm; schm = NULL;
+	//rinf->MP4SchemeInfo = (MP4AtomPtr)schi; schi = NULL;
+	rinf->addAtom(rinf, (MP4AtomPtr)frma); frma = NULL;
+	rinf->addAtom(rinf, (MP4AtomPtr)schm); schm = NULL;
+	rinf->addAtom(rinf, (MP4AtomPtr)schi); schi = NULL;
 
 	self->type = self->restriction_type;
 
 	/* set */
-	self->MP4RestrictedSchemeInfo = (MP4AtomPtr)rinf;
+	//self->MP4RestrictedSchemeInfo = (MP4AtomPtr)rinf;
+	self->addAtom(self, (MP4AtomPtr)rinf);
 
 bail:
 	if (frma)  frma->destroy((MP4AtomPtr)frma);

--- a/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
+++ b/IsoLib/libisomediafile/src/RestrictedVideoSampleEntry.c
@@ -83,8 +83,8 @@ static MP4Err serialize(struct MP4Atom* s, char* buffer)
 	PUT16(reserved8);
 	PUT16(reserved9);
 
-	SERIALIZE_ATOM_LIST(ExtensionAtomList);
 	SERIALIZE_ATOM(MP4RestrictedSchemeInfo);
+	SERIALIZE_ATOM_LIST(ExtensionAtomList);
 
 	assert(self->bytesWritten == self->size);
 
@@ -148,6 +148,10 @@ static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
 	GETBYTES(31, name31);
 	GET16(reserved8);
 	GET16(reserved9);
+	GETATOM(MP4RestrictedSchemeInfo);
+	GETATOM_LIST(ExtensionAtomList);
+	//PARSE_ATOM_INCLUDES(MP4RestrictedVideoSampleEntryAtom);
+	/*
 	while (self->bytesRead < self->size)
 	{
 		MP4AtomPtr atom;
@@ -161,11 +165,12 @@ static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
 			if (err) goto bail;
 		}
 	}
+	*/
 
 	if (self->bytesRead != self->size)
-		BAILWITHERROR(MP4BadDataErr)
+		BAILWITHERROR(MP4BadDataErr);
 
-	bail:
+bail:
 	TEST_RETURN(err);
 
 	return err;
@@ -373,6 +378,7 @@ MP4Err MP4CreateRestrictedVideoSampleEntryAtom(MP4RestrictedVideoSampleEntryAtom
 	self->getSchemeInfoAtom = getSchemeInfoAtom;
 	self->getScheme = getScheme;
 	self->transform = transform;
+	self->addAtom = addAtom;
 
 	err = MP4MakeLinkedList(&self->ExtensionAtomList); if (err) goto bail;
 


### PR DESCRIPTION
This fixes a couple of bugs related to the construction of a restricted video sample entry.