### PR TITLE
Fix several HEVCExtractorReader issues related to 14496-15:2014/Cor.3

### DIFF
--- a/IsoLib/hevc_extractors/src/HEVCExtractorReader.cpp
+++ b/IsoLib/hevc_extractors/src/HEVCExtractorReader.cpp
@@ -217,6 +217,15 @@ uint32_t HEVCExtractorReader::getNextSampleNr(uint32_t uiTrackID) const
   return reader->nextSampleNumber;
 }
 
+std::vector<char> HEVCExtractorReader::getNextSample()
+{
+  if(isHvc2Track(m_uiSelectedTrackID))
+  {
+    return getNextAUResolveExtractors();
+  }
+  return getNextAUwithoutExtractors();
+}
+
 int32_t HEVCExtractorReader::getNextAU(uint32_t uiTrackID,
                                  ISOHandle sampleH,
                                  uint32_t* pUiSize)
@@ -296,6 +305,7 @@ std::vector<char> HEVCExtractorReader::getNextAUResolveExtractors()
 
           // set data_offset and data_length fields dependent on length_size_minus_one flag
           uint32_t uiLengthSizeMinusOne = m_mLenSizeMinOne.at(m_uiSelectedTrackID);
+
           switch(uiLengthSizeMinusOne)
           {
           case 0:
@@ -493,13 +503,16 @@ int32_t HEVCExtractorReader::init(std::string strFileName, bool bForce)
     m_mTrackReaders[uiTrackID] = pReader;
 
     // get LengthSizeMinusOne flags
-    uint32_t uiLenSizeMinOne = 0;
-    err = getLengthSizeMinusOneFlag(uiTrackID, uiLenSizeMinOne);
-    if(err)
+    uint32_t uiLenSizeMinOne = m_uiDefLenSizeMinOne;
+    if(m_uiDefLenSizeMinOne==0)
     {
-      std::cerr << "could not get lensizeminusone flag: "<< err << std::endl;
-      if(!bForce) continue;
-      uiLenSizeMinOne = 3;
+      err = getLengthSizeMinusOneFlag(uiTrackID, uiLenSizeMinOne);
+      if(err)
+      {
+        std::cerr << "could not get lensizeminusone flag: "<< err << std::endl;
+        if(!bForce) continue;
+        uiLenSizeMinOne = 3;
+      }
     }
     m_mLenSizeMinOne[uiTrackID] = uiLenSizeMinOne;
 

--- a/IsoLib/hevc_extractors/src/HEVCExtractorReader.cpp
+++ b/IsoLib/hevc_extractors/src/HEVCExtractorReader.cpp
@@ -31,13 +31,14 @@
 #include <fstream>
 #include <sstream>
 #include <algorithm>
+#include <set>
 
 #include <MP4TrackReader.h>
 
 extern "C"
 {
 MP4_EXTERN(MP4Err) ISOGetRESVOriginalFormat(MP4Handle sampleEntryH,
-                                            char* pOrigFmt);
+                                            u32* outOrigFmt);
 MP4_EXTERN(MP4Err) ISOGetRESVSampleDescriptionPS(MP4Handle sampleEntryH,
                                                  MP4Handle ps,
                                                  u32 where,
@@ -143,11 +144,16 @@ std::string HEVCExtractorReader::getOriginalFormat(uint32_t uiTrackID) const
   ISOHandle sampleEntryH;
   ISONewHandle(1, &sampleEntryH);
   err = MP4TrackReaderGetCurrentSampleDescription(*pTrackReader, sampleEntryH);
+
   if(MP4NoErr==err)
   {
-    char origFmt[5];
-    err = ISOGetRESVOriginalFormat(sampleEntryH, origFmt);
-    if(MP4NoErr==err) { strRet = origFmt; }
+    uint32_t uiOrigFormat = 0;
+    err = ISOGetRESVOriginalFormat(sampleEntryH, &uiOrigFormat);
+    if(MP4NoErr==err)
+    {
+      if(uiOrigFormat==ISOHEVCSampleEntryAtomType) { strRet = "hvc1"; }
+      else if(uiOrigFormat==ISOLHEVCSampleEntryAtomType) { strRet = "hvc2"; }
+    }
   }
   ISODisposeHandle(sampleEntryH);
   return strRet;
@@ -249,6 +255,10 @@ std::vector<char> HEVCExtractorReader::getNextAUResolveExtractors()
   ISOHandle sampleH;
   ISONewHandle(0, &sampleH);
 
+  // TODO: remove it when seeking is implemented
+  TrackIDSet rUsedTrackIds;
+  rUsedTrackIds.push_back(m_uiSelectedTrackID);
+
   err = getNextAU(m_uiSelectedTrackID, sampleH, &uiSize);
   if(err || uiSize==0) { return vRet; }
 
@@ -300,6 +310,16 @@ std::vector<char> HEVCExtractorReader::getNextAUResolveExtractors()
                            ( (*(*sampleH+uiCurNalPtr+uiConstrStart+1))&0xff);
             uiConstrStart += 2;
             break;
+          case 2:
+              uiDataOffset = (((*(*sampleH+uiCurNalPtr+uiConstrStart))&0xff) << 16)   |
+                             (((*(*sampleH+uiCurNalPtr+uiConstrStart+1))&0xff) << 8)  |
+                             ( (*(*sampleH+uiCurNalPtr+uiConstrStart+2))&0xff);
+              uiConstrStart += 3;
+              uiDataLength = (((*(*sampleH+uiCurNalPtr+uiConstrStart))&0xff) << 16) |
+                             (((*(*sampleH+uiCurNalPtr+uiConstrStart+1))&0xff) << 8)  |
+                             ( (*(*sampleH+uiCurNalPtr+uiConstrStart+2))&0xff);
+              uiConstrStart += 3;
+              break;
           case 3:
             uiDataOffset = (((*(*sampleH+uiCurNalPtr+uiConstrStart))&0xff) << 24)   |
                            (((*(*sampleH+uiCurNalPtr+uiConstrStart+1))&0xff) << 16) |
@@ -318,6 +338,8 @@ std::vector<char> HEVCExtractorReader::getNextAUResolveExtractors()
 
           // get trackID of the track we depend on in this sample constructor
           uint32_t uiRefTrackID = m_mHvc2Dependencies[m_uiSelectedTrackID].at(uiTrackRefIdx-1);
+
+          rUsedTrackIds.push_back(uiRefTrackID);
 
           // get the correct sample number
           if(0!=iSampleOffset)
@@ -345,7 +367,7 @@ std::vector<char> HEVCExtractorReader::getNextAUResolveExtractors()
           }
           if(uiDataOffset+uiDataLength != uiRefSampleSize)
           {
-            if(uiDataOffset+uiDataLength > uiRefSampleSize)
+            if(static_cast<uint64_t>(uiDataOffset)+uiDataLength > uiRefSampleSize)
             {
               //When data_offset + data_length is greater than the size of the sample, the bytes from the byte
               // pointed to by data_offset until the end of the sample, inclusive, are copied
@@ -365,7 +387,7 @@ std::vector<char> HEVCExtractorReader::getNextAUResolveExtractors()
           if(0 > iNaluLengthIdx) { iNaluLengthIdx = vRet.size(); }
           uint32_t uiLengthInline = *(*sampleH+uiCurNalPtr+uiConstrStart++);
 
-          // write data from inline constructor to the ouput vector          
+          // write data from inline constructor to the output vector
           vRet.insert(vRet.end(),
                       *sampleH+uiCurNalPtr+uiConstrStart,
                       *sampleH+uiCurNalPtr+uiConstrStart+uiLengthInline);
@@ -380,20 +402,35 @@ std::vector<char> HEVCExtractorReader::getNextAUResolveExtractors()
           continue;
         }
       }while(!bEndOfNalU);
+
       if(bNaluLengthRewrite)
       {
+        uiNaluLengthCorrect -= 4;
+        setLengthField(vRet, iNaluLengthIdx, uiNaluLengthCorrect);
+      }
+
+      uint32_t uiNaluLengthParsed = getLengthField(vRet, iNaluLengthIdx);
+
+      if(uiNaluLengthCorrect<uiNaluLengthParsed)
+      {
+        // Resolution of an extractor may result in a reconstructed payload for which there are fewer
+        // bytes than what is indicated in the NALUnitLength of the first NAL in that reconstructed payload.
+        // In such cases, readers shall assume that only a single NAL unit was reconstructed by the
+        // extractors, and shall rewrite the NALUnitLength of that NAL to the appropriate value
         uiNaluLengthCorrect -= 4;
         setLengthField(vRet, iNaluLengthIdx, uiNaluLengthCorrect);
       }
     }
     else
     {
-      // NALU is not of type 49 (Extractors) write the entire NALU to ret
+      std::cout << " NALU is not of type 49 (Extractors) copy the entire NALU\n";
       vRet.insert(vRet.end(),
-                  *sampleH+uiCurNalPtr,
-                  *sampleH+uiCurNalPtr+uiNalSize);
+                  *sampleH+uiCurNalPtr-4,
+                  *sampleH+uiCurNalPtr-4+uiNalSize);
+      setLengthField(vRet, vRet.size()-uiNalSize, uiNalSize-4); // replace the length field with payload length only
     }
   }
+  skipNotUsedAUs(rUsedTrackIds);
   ISODisposeHandle(sampleH);
   return vRet;
 }
@@ -562,4 +599,36 @@ void HEVCExtractorReader::setLengthField(std::vector<char>& rvSample, uint32_t u
   rvSample[uiPointer+1] = (uiSize>>16)&0xff;
   rvSample[uiPointer+2] = (uiSize>>8)&0xff;
   rvSample[uiPointer+3] = (uiSize)&0xff;
+}
+
+void HEVCExtractorReader::skipNotUsedAUs(TrackIDSet& rUsedTrackIds)
+{
+  // just to be sure that we dont skip multiple samples from the same track
+  std::set<uint32_t> uniqueUsedIDs, uniqueNotUsedIDs;
+  for(TrackIDSet::iterator it=rUsedTrackIds.begin(); it!=rUsedTrackIds.end(); it++)
+  {
+    uniqueUsedIDs.insert(*it);
+  }
+
+  // get all unique not used trackIDs
+  for(TrackIDSet::iterator it=m_vHvc1TrackIDs.begin(); it!=m_vHvc1TrackIDs.end(); it++)
+  { // hvc1 tracks
+    if(uniqueUsedIDs.find(*it) == uniqueUsedIDs.end()) { uniqueNotUsedIDs.insert(*it); }
+  }
+  for(TrackIDSet::iterator it=m_vHvc2TrackIDs.begin(); it!=m_vHvc2TrackIDs.end(); it++)
+  { // hvc2 tracks
+    if(uniqueUsedIDs.find(*it) == uniqueUsedIDs.end()) { uniqueNotUsedIDs.insert(*it); }
+  }
+
+  // skip AUs
+  ISOErr err;
+  ISOHandle sampleSkip;
+  ISONewHandle(0, &sampleSkip);
+  uint32_t uiSize = 0;
+  for(std::set<uint32_t>::iterator it=uniqueNotUsedIDs.begin(); it!=uniqueNotUsedIDs.end(); it++)
+  {
+    err = getNextAU(*it, sampleSkip, &uiSize);
+    if(err) {assert(0); continue; }
+  }
+  ISODisposeHandle(sampleSkip);
 }

--- a/IsoLib/hevc_extractors/src/HEVCExtractorReader.h
+++ b/IsoLib/hevc_extractors/src/HEVCExtractorReader.h
@@ -143,6 +143,10 @@ private:
   uint32_t          getLengthField(std::vector<char>& rvSample, uint32_t uiPointer) const;
   void              setLengthField(std::vector<char>& rvSample, uint32_t uiPointer, uint32_t uiSize) const;
 
+  // this is a hack function since we don't have seeking implemented now
+  // TODO: implement seeking and remove this method
+  void              skipNotUsedAUs(TrackIDSet& rUsedTrackIds);
+
 ////////////////////////////////// MEMBERS //////////////////////////////////
 private:
   bool              m_bInitialized;     // initialized flag

--- a/IsoLib/hevc_extractors/src/HEVCExtractorReader.h
+++ b/IsoLib/hevc_extractors/src/HEVCExtractorReader.h
@@ -79,6 +79,11 @@ public:
   ///
   uint32_t          getNextSampleNr(uint32_t uiTrackID)               const;
   ///
+  /// \brief getNextSample return next AU (automatically select if extractors needs to be resolved or not)
+  /// \return
+  ///
+  std::vector<char> getNextSample();
+  ///
   /// \brief getNextAUwithoutExtractors return next AU without resolving extractors
   /// \return data
   ///
@@ -130,6 +135,12 @@ public:
   ///
   void              replaceLFwithSC(std::vector<char>& rvSample) const;
 
+  ///
+  /// \brief setDefaultLenSizeMinOne this function is a temporary bugfix, this information should be parsed from the file
+  /// \param uiDefaultVal default value for all tracks in the file. if set to 0 parsing from the config record is forced
+  ///
+  void setDefaultLenSizeMinOne(uint32_t uiDefaultVal) { m_uiDefLenSizeMinOne = uiDefaultVal; }
+
 private:
   int32_t           getPSfromSampleEntry(ISOHandle sampleEntryH,
                                          ISOHandle vpsH,
@@ -157,4 +168,5 @@ private:
   uint32_t          m_uiSelectedTrackID;// trackID of selected track
   TrackReaderPtrMap m_mTrackReaders;    // one track reader per track
   LenSizeMinOneMap  m_mLenSizeMinOne;   // lenght_size_minus_one for each track
+  uint32_t          m_uiDefLenSizeMinOne; // default lenght_size_minus_one value todo: remove it after bugfix in libisomendiafile
 };

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -132,6 +132,7 @@ enum
     ISOHEVCConfigAtomType                               = MP4_FOUR_CHAR_CODE( 'h', 'v', 'c', 'C' ),
     ISOAVCSampleEntryAtomType                           = MP4_FOUR_CHAR_CODE( 'a', 'v', 'c', '1' ),
     ISOHEVCSampleEntryAtomType                          = MP4_FOUR_CHAR_CODE( 'h', 'v', 'c', '1' ),
+    ISOLHEVCSampleEntryAtomType                         = MP4_FOUR_CHAR_CODE( 'h', 'v', 'c', '2' ),
     MP4XMLMetaSampleEntryAtomType                       = MP4_FOUR_CHAR_CODE( 'm', 'e', 't', 'x' ),
     MP4TextMetaSampleEntryAtomType                      = MP4_FOUR_CHAR_CODE( 'm', 'e', 't', 't' ),
     MP4AMRSampleEntryAtomType                           = MP4_FOUR_CHAR_CODE( 's', 'a', 'm', 'r' ),


### PR DESCRIPTION
This fixes a couple of issues related to resolving of HEVC extractors (hvc2 track) as discussed during MPEG 124 meeting in Macao. Remaining changes from ISO/IEC 14496-15:2014/Cor.3 are now considered. See contribution m44614 for more details.