### PR TITLE
Fix build issue for VS2008

### DIFF
--- a/IsoLib/libisomediafile/src/SubsegmentIndexAtom.c
+++ b/IsoLib/libisomediafile/src/SubsegmentIndexAtom.c
@@ -192,10 +192,10 @@ static MP4Err calculateSize(struct MP4Atom* s)
     self->size += 4;
 
     for (i = 0; i < self->subsegmentCount; i++) {
-        
+        SubsegmentPtr ss;
+
         self->size += 4;
 
-        SubsegmentPtr ss;
         err = MP4GetListEntry(self->subsegmentsList, i, (char**)&ss);
         if (err) goto bail;
 

--- a/IsoLib/libisomediafile/w32/libisomediafile/VS2008/libisomedia.vcproj
+++ b/IsoLib/libisomediafile/w32/libisomediafile/VS2008/libisomedia.vcproj
@@ -4424,6 +4424,46 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="..\..\..\src\PCMConfigAtom.c"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
 				RelativePath="..\..\..\src\PrimaryItemAtom.c"
 				>
 				<FileConfiguration


### PR DESCRIPTION
Hello,
I'm Daniel Richter from Fraunhofer IIS, mainly working in the Audio WG on the MPEG-H 3D Audio reference software.
I noticed that for VS2008 the isobmff reference software is not compiling with the 3D Audio reference software. Therefore I request to adapt the corresponding libisomedia.vcproj file to fix this issue.
Kind regards,
Daniel