### PR TITLE
hevc extractors for non OMAF files

### DIFF
--- a/IsoLib/hevc_extractors/src/HEVCExtractorReader.cpp
+++ b/IsoLib/hevc_extractors/src/HEVCExtractorReader.cpp
@@ -411,6 +411,7 @@ std::vector<char> HEVCExtractorReader::getNextAUResolveExtractors()
               uiDataLength = uiRefSampleSize - uiDataOffset;
               bNaluLengthRewrite = true;
             }
+            else { assert(0); }
           }
           // now get the right portion of the sample and write it to the output vector
           vRet.insert(vRet.end(), *sampleFromConstrH+uiDataOffset, *sampleFromConstrH+uiDataOffset+uiDataLength);

--- a/IsoLib/hevc_extractors/src/HEVCExtractorReader.cpp
+++ b/IsoLib/hevc_extractors/src/HEVCExtractorReader.cpp
@@ -49,8 +49,8 @@ MP4_EXTERN(MP4Err) ISOGetHEVCSampleDescriptionPS(MP4Handle sampleEntryH,
                                                  u32 index);
 MP4_EXTERN(MP4Err) ISOGetRESVLengthSizeMinusOne(MP4Handle sampleEntryH,
                                                 u32* out);
+MP4_EXTERN ( MP4Err ) ISOGetSampleDescriptionType(MP4Handle sampleEntryH, u32 *type);
 }
-
 
 int32_t HEVCExtractorReader::getPSfromSampleEntry(ISOHandle sampleEntryH, ISOHandle vpsH, ISOHandle spsH, ISOHandle ppsH) const
 {
@@ -132,6 +132,33 @@ int32_t HEVCExtractorReader::getLengthSizeMinusOneFlag(uint32_t uiTrackID, uint3
 
   ISODisposeHandle(sampleEntryH);
   return err;
+}
+
+std::string HEVCExtractorReader::getSampleEntryType(uint32_t uiTrackID) const
+{
+  ISOErr err;
+  std::string strRet = std::string();
+  ISOTrackReader* pTrackReader = getTrackReader(uiTrackID);
+  if(!pTrackReader) { return strRet; }
+
+  ISOHandle sampleEntryH;
+  ISONewHandle(1, &sampleEntryH);
+  err = MP4TrackReaderGetCurrentSampleDescription(*pTrackReader, sampleEntryH);
+
+  if(MP4NoErr==err)
+  {
+    u32 type;
+    err = ISOGetSampleDescriptionType(sampleEntryH, &type);
+    if(MP4NoErr==err)
+    {
+      strRet += static_cast<char>((type >> 24) & 255);
+      strRet += static_cast<char>((type >> 16) & 255);
+      strRet += static_cast<char>((type >> 8) & 255);
+      strRet += static_cast<char>((type) & 255);
+    }
+  }
+  ISODisposeHandle(sampleEntryH);
+  return strRet;
 }
 
 std::string HEVCExtractorReader::getOriginalFormat(uint32_t uiTrackID) const
@@ -384,7 +411,6 @@ std::vector<char> HEVCExtractorReader::getNextAUResolveExtractors()
               uiDataLength = uiRefSampleSize - uiDataOffset;
               bNaluLengthRewrite = true;
             }
-            else { assert(0); } // this should not happen if the file is OMAF compliant
           }
           // now get the right portion of the sample and write it to the output vector
           vRet.insert(vRet.end(), *sampleFromConstrH+uiDataOffset, *sampleFromConstrH+uiDataOffset+uiDataLength);
@@ -520,12 +546,17 @@ int32_t HEVCExtractorReader::init(std::string strFileName, bool bForce)
     setNextSampleNr(uiTrackID, getCurrentSampleNr(uiTrackID)+1);
 
     // get original format
-    std::string strOriginalFormat = getOriginalFormat(uiTrackID);
-    if(strOriginalFormat.find("hvc1")!=std::string::npos)
+    std::string strSampleEntryType = getSampleEntryType(uiTrackID);
+    if(strSampleEntryType.find("resv")!=std::string::npos)
+    {
+      strSampleEntryType = getOriginalFormat(uiTrackID);
+    }
+
+    if(strSampleEntryType.find("hvc1")!=std::string::npos)
     {
       m_vHvc1TrackIDs.push_back(uiTrackID);
     }
-    else if(strOriginalFormat.find("hvc2")!=std::string::npos)
+    else if(strSampleEntryType.find("hvc2")!=std::string::npos)
     {
       m_vHvc2TrackIDs.push_back(uiTrackID);
       m_mHvc2Dependencies[uiTrackID] = getRefTrackIDs(trak);

--- a/IsoLib/hevc_extractors/src/HEVCExtractorReader.h
+++ b/IsoLib/hevc_extractors/src/HEVCExtractorReader.h
@@ -51,6 +51,8 @@ public:
   int32_t           getPSwithStartCodesFromTrack(uint32_t uiTrackID,
                                                  std::vector<char>& rvOut)  const;
   ///
+  std::string       getSampleEntryType(uint32_t uiTrackID)            const;
+  ///
   /// \brief getOriginalFormat returns the original_format string
   /// \param uiTrackID which track to select
   /// \return original_format string

--- a/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
+++ b/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
@@ -1042,7 +1042,7 @@ MP4_EXTERN(MP4Err) ISOGetHEVCSampleDescriptionPS(MP4Handle sampleEntryH,
 
 	err = sampleEntryHToAtomPtr(sampleEntryH, (MP4AtomPtr *)&entry, MP4VisualSampleEntryAtomType); if (err) goto bail;
 
-	if (entry->type != ISOHEVCSampleEntryAtomType) BAILWITHERROR(MP4BadParamErr);
+	if (entry->type != ISOHEVCSampleEntryAtomType && entry->type != ISOLHEVCSampleEntryAtomType) BAILWITHERROR(MP4BadParamErr);
 	err = MP4GetListEntryAtom(entry->ExtensionAtomList, ISOHEVCConfigAtomType, (MP4AtomPtr*)&config);
 	if (err == MP4NotFoundErr) {
 		BAILWITHERROR(MP4BadDataErr);

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -1976,6 +1976,8 @@ MP4Err MP4CreateItemPropertiesAtom(MP4ItemPropertiesAtomPtr *outAtom);
 MP4Err MP4CreateItemPropertyContainerAtom(MP4ItemPropertyContainerAtomPtr *outAtom);
 MP4Err MP4CreateItemPropertyAssociationAtom(MP4ItemPropertyAssociationAtomPtr *outAtom);
 
+MP4Err MP4CreateHEVCConfigAtom(ISOHEVCConfigAtomPtr *outAtom);
+
 MP4Err MP4CreateOriginalFormatAtom(MP4OriginalFormatAtomPtr *outAtom);
 MP4Err MP4CreateSchemeInfoAtom(MP4SchemeInfoAtomPtr *outAtom);
 MP4Err MP4CreateRestrictedSchemeInfoAtom(MP4RestrictedSchemeInfoAtomPtr *outAtom);


### PR DESCRIPTION
So far only OMAF use-case was implemented for hevc extractors. We extend the implementation to support hvc2 tracks without resv sample entry. One example is the ISOBMFF-Conformance/nalu/hevc/hvc2_extractors.mp4 conformance file which can now also be processed by the software.