### PR TITLE
Fixes macOS build of applications using the macro PUTBYTES(...)

### DIFF
--- a/IsoLib/libisomediafile/src/MP4Impl.h
+++ b/IsoLib/libisomediafile/src/MP4Impl.h
@@ -27,9 +27,7 @@ derivative works. Copyright (c) 1999.
 #define INCLUDED_MP4IMPL_H
 #include <assert.h>
 #include <stdio.h>
-#ifdef __linux
 #include <string.h>
-#endif
 
 #ifndef NULL
 #define NULL 0


### PR DESCRIPTION
Fixes the following issue:

Using the Macro
  #define PUTBYTES( src, len )
from
  isobmff/IsoLib/libisomediafile/src/MP4Impl.h
on
  macOS, unix-based platforms other than Linux
currently leads to a compiler error in the MPEG-H Refsoft, if the target application does not include string.h.
The reason for that is a directive #ifdef __linux, which encapsulates the string.h include in MP4Impl.h,
making it unavailable for macOS and other unix-based platforms (except for Linux).
