### PR TITLE
Bugfix/memory leak

### DIFF
--- a/IsoLib/libisomediafile/src/MP4MovieFile.c
+++ b/IsoLib/libisomediafile/src/MP4MovieFile.c
@@ -352,7 +352,10 @@ ISOStartMovieFragment(MP4Movie theMovie)
   MP4MovieExtendsAtomPtr mvex;
   MP4MediaDataAtomPtr mdat;
   MP4MovieAtomPtr moov;
+  MP4TrackFragmentAtomPtr traf;
+
   u32 fragment_sequence;
+  u32 i;
 
   err   = MP4NoErr;
   movie = (MP4PrivateMovieRecordPtr)theMovie;
@@ -378,6 +381,12 @@ ISOStartMovieFragment(MP4Movie theMovie)
     moof              = (MP4MovieFragmentAtomPtr)movie->moovAtomPtr;
     mfhd              = (MP4MovieFragmentHeaderAtomPtr)moof->mfhd;
     fragment_sequence = mfhd->sequence_number + 1;
+    for (i=0; i<moof->atomList->entryCount; i++)
+    {
+        err = MP4GetListEntry(moof->atomList, i, (char **)&traf);
+        if (err) goto bail;
+        traf->destroy((MP4AtomPtr)traf);
+    }
     moof->destroy(movie->moovAtomPtr); /* the old moof */
   }
   else

--- a/IsoLib/libisomediafile/src/MP4MovieFile.c
+++ b/IsoLib/libisomediafile/src/MP4MovieFile.c
@@ -381,11 +381,11 @@ ISOStartMovieFragment(MP4Movie theMovie)
     moof              = (MP4MovieFragmentAtomPtr)movie->moovAtomPtr;
     mfhd              = (MP4MovieFragmentHeaderAtomPtr)moof->mfhd;
     fragment_sequence = mfhd->sequence_number + 1;
-    for (i=0; i<moof->atomList->entryCount; i++)
+    for(i = 0; i < moof->atomList->entryCount; i++)
     {
-        err = MP4GetListEntry(moof->atomList, i, (char **)&traf);
-        if (err) goto bail;
-        traf->destroy((MP4AtomPtr)traf);
+      err = MP4GetListEntry(moof->atomList, i, (char **)&traf);
+      if(err) goto bail;
+      traf->destroy((MP4AtomPtr)traf);
     }
     moof->destroy(movie->moovAtomPtr); /* the old moof */
   }

--- a/IsoLib/libisomediafile/src/MP4Movies.c
+++ b/IsoLib/libisomediafile/src/MP4Movies.c
@@ -74,6 +74,20 @@ MP4_EXTERN(MP4Err) MP4DisposeMovie(MP4Movie theMovie)
 
     dh->close(dh);
   }
+  
+  if(moov->moovAtomPtr->type == MP4MovieFragmentAtomType)
+  {
+    MP4MovieFragmentAtomPtr moof;
+    MP4TrackFragmentAtomPtr traf;
+    u32 i;
+    moof = (MP4MovieFragmentAtomPtr)moov->moovAtomPtr;
+    for (i=0; i<moof->atomList->entryCount; i++)
+    {
+        err = MP4GetListEntry(moof->atomList, i, (char **)&traf);
+        if (err) goto bail;
+        traf->destroy((MP4AtomPtr)traf);
+    }
+  }
 
   if(moov->moovAtomPtr) moov->moovAtomPtr->destroy(moov->moovAtomPtr);
 

--- a/IsoLib/libisomediafile/src/MP4Movies.c
+++ b/IsoLib/libisomediafile/src/MP4Movies.c
@@ -79,13 +79,28 @@ MP4_EXTERN(MP4Err) MP4DisposeMovie(MP4Movie theMovie)
   {
     MP4MovieFragmentAtomPtr moof;
     MP4TrackFragmentAtomPtr traf;
+    MP4MovieAtomPtr movieAtom;
+    MP4TrackExtendsAtomPtr trex;
     u32 i;
+    u32 trackTotalCount;
+
     moof = (MP4MovieFragmentAtomPtr)moov->moovAtomPtr;
-    for (i=0; i<moof->atomList->entryCount; i++)
+    for (i = 0; i < moof->atomList->entryCount; i++)
     {
         err = MP4GetListEntry(moof->atomList, i, (char **)&traf);
         if (err) goto bail;
         traf->destroy((MP4AtomPtr)traf);
+    }
+
+    movieAtom = (MP4MovieAtomPtr)moov->true_moov;
+    trackTotalCount = movieAtom->getTrackCount(movieAtom);
+    if (trackTotalCount != 0)
+    {
+        for (i = 1; i <= trackTotalCount; i++)
+        {
+            movieAtom->getTrackExtendsAtom(movieAtom, i, (MP4AtomPtr*)&trex);
+            trex->destroy((MP4AtomPtr)trex);
+        }
     }
   }
 

--- a/IsoLib/libisomediafile/src/MP4Movies.c
+++ b/IsoLib/libisomediafile/src/MP4Movies.c
@@ -74,7 +74,7 @@ MP4_EXTERN(MP4Err) MP4DisposeMovie(MP4Movie theMovie)
 
     dh->close(dh);
   }
-  
+
   if(moov->moovAtomPtr->type == MP4MovieFragmentAtomType)
   {
     MP4MovieFragmentAtomPtr moof;
@@ -85,22 +85,22 @@ MP4_EXTERN(MP4Err) MP4DisposeMovie(MP4Movie theMovie)
     u32 trackTotalCount;
 
     moof = (MP4MovieFragmentAtomPtr)moov->moovAtomPtr;
-    for (i = 0; i < moof->atomList->entryCount; i++)
+    for(i = 0; i < moof->atomList->entryCount; i++)
     {
-        err = MP4GetListEntry(moof->atomList, i, (char **)&traf);
-        if (err) goto bail;
-        traf->destroy((MP4AtomPtr)traf);
+      err = MP4GetListEntry(moof->atomList, i, (char **)&traf);
+      if(err) goto bail;
+      traf->destroy((MP4AtomPtr)traf);
     }
 
-    movieAtom = (MP4MovieAtomPtr)moov->true_moov;
+    movieAtom       = (MP4MovieAtomPtr)moov->true_moov;
     trackTotalCount = movieAtom->getTrackCount(movieAtom);
-    if (trackTotalCount != 0)
+    if(trackTotalCount != 0)
     {
-        for (i = 1; i <= trackTotalCount; i++)
-        {
-            movieAtom->getTrackExtendsAtom(movieAtom, i, (MP4AtomPtr*)&trex);
-            trex->destroy((MP4AtomPtr)trex);
-        }
+      for(i = 1; i <= trackTotalCount; i++)
+      {
+        movieAtom->getTrackExtendsAtom(movieAtom, i, (MP4AtomPtr *)&trex);
+        trex->destroy((MP4AtomPtr)trex);
+      }
     }
   }
 

--- a/IsoLib/libisomediafile/src/MovieFragmentAtom.c
+++ b/IsoLib/libisomediafile/src/MovieFragmentAtom.c
@@ -34,7 +34,8 @@ static void destroy(MP4AtomPtr s)
 
   self = (MP4MovieFragmentAtomPtr)s;
   if(self == NULL) BAILWITHERROR(MP4BadParamErr)
-  DESTROY_ATOM_LIST_F(atomList);
+  err = MP4DeleteLinkedList(self->atomList);
+  if(err) goto bail;
   (self->mfhd)->destroy((MP4AtomPtr)(self->mfhd));
   if(self->super) self->super->destroy(s);
 

--- a/IsoLib/libisomediafile/src/TrackFragmentAtom.c
+++ b/IsoLib/libisomediafile/src/TrackFragmentAtom.c
@@ -37,6 +37,9 @@ static void destroy(MP4AtomPtr s)
   DESTROY_ATOM_LIST_F(atomList);
   DESTROY_ATOM_LIST_F(sampletoGroupList);
   DESTROY_ATOM_LIST_F(groupDescriptionList);
+  DESTROY_ATOM_LIST_F(saizList);
+  DESTROY_ATOM_LIST_F(saioList);
+
   (self->tfhd)->destroy((MP4AtomPtr)(self->tfhd));
   if(self->tfdt) (self->tfdt)->destroy((MP4AtomPtr)(self->tfdt));
 


### PR DESCRIPTION
First, Solved Memory Leak in traf (MP4TrackFragmentAtom)  
Second, Solved Memory Leak in trex (MP4TrackExtendsAtom)  

If user makes Fragment Mp4, There are some memory leak.  
There is no memory free  for MP4TrackFragmentAtom.  
There is no memory free  for MP4TrackExtendsAtom.  

After add Code and completing the test, There is no memory leak.  
