### PR TITLE
clang-format.yml version change

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
-      uses: jidicula/clang-format-action@v4.4.1
+      uses: jidicula/clang-format-action@v4.11.0
       with:
         clang-format-version: '13'
         check-path: 'IsoLib/libisomediafile'


### PR DESCRIPTION
I think that you need to change the clang-format.yml file (version up)    
If I use jidicula/clang-format-action@v4.4.1 version, The error raised like below.
```
Installing clang-format-13
E: Unable to locate package clang-format-13
Not a directory in the workspace, fallback to all files.
/entrypoint.sh: line 23: /usr/bin/clang-format-13: No such file or directory
```
https://github.com/MPEGGroup/isobmff/blob/master/.github/workflows/clang-format.yml   

jidicula/clang-format-action@v4.4.1 -> jidicula/clang-format-action@v4.11.0  
or  
jidicula/clang-format-action@v4.9.0   
Thank you  