### PR TITLE
BugFix in newly added function rewindData()

### DIFF
--- a/IsoLib/libisomediafile/src/MP4FileMappingInputStream.c
+++ b/IsoLib/libisomediafile/src/MP4FileMappingInputStream.c
@@ -165,7 +165,7 @@ static MP4Err rewindData(struct MP4InputStreamRecord *s, u64 bytes, char *msg)
 
   err = MP4NoErr;
 
-  CHECK_AVAIL(bytes)
+  //CHECK_AVAIL(bytes)
   self->available += bytes;
   self->current_offset -= bytes;
 

--- a/IsoLib/libisomediafile/src/MP4FileMappingInputStream.c
+++ b/IsoLib/libisomediafile/src/MP4FileMappingInputStream.c
@@ -165,7 +165,6 @@ static MP4Err rewindData(struct MP4InputStreamRecord *s, u64 bytes, char *msg)
 
   err = MP4NoErr;
 
-  //CHECK_AVAIL(bytes)
   self->available += bytes;
   self->current_offset -= bytes;
 

--- a/IsoLib/libisomediafile/src/MP4FileMappingInputStream.c
+++ b/IsoLib/libisomediafile/src/MP4FileMappingInputStream.c
@@ -163,6 +163,7 @@ static MP4Err rewindData(struct MP4InputStreamRecord *s, u64 bytes, char *msg)
   MP4Err err;
   MP4FileMappingInputStreamPtr self = (MP4FileMappingInputStreamPtr)s;
 
+  if(bytes > self->current_offset) BAILWITHERROR(MP4BadParamErr);
   err = MP4NoErr;
 
   self->available += bytes;

--- a/IsoLib/libisomediafile/src/MP4MemoryInputStream.c
+++ b/IsoLib/libisomediafile/src/MP4MemoryInputStream.c
@@ -175,7 +175,7 @@ static MP4Err rewindData(struct MP4InputStreamRecord *s, u64 bytes, char *msg)
 
   err = MP4NoErr;
 
-  CHECK_AVAIL(bytes)
+  //CHECK_AVAIL(bytes)
   self->available += bytes;
   self->current_offset -= bytes;
 

--- a/IsoLib/libisomediafile/src/MP4MemoryInputStream.c
+++ b/IsoLib/libisomediafile/src/MP4MemoryInputStream.c
@@ -173,6 +173,7 @@ static MP4Err rewindData(struct MP4InputStreamRecord *s, u64 bytes, char *msg)
   MP4Err err;
   MP4FileMappingInputStreamPtr self = (MP4FileMappingInputStreamPtr)s;
 
+  if(bytes > self->current_offset) BAILWITHERROR(MP4BadParamErr);
   err = MP4NoErr;
 
   self->available += bytes;

--- a/IsoLib/libisomediafile/src/MP4MemoryInputStream.c
+++ b/IsoLib/libisomediafile/src/MP4MemoryInputStream.c
@@ -175,7 +175,6 @@ static MP4Err rewindData(struct MP4InputStreamRecord *s, u64 bytes, char *msg)
 
   err = MP4NoErr;
 
-  //CHECK_AVAIL(bytes)
   self->available += bytes;
   self->current_offset -= bytes;
 


### PR DESCRIPTION
For rewinding pointer, not necessary to check the available bytes.