### PR TITLE
Add t35_identifier_length and move descr to hrsd

### DIFF
--- a/IsoLib/isoiff_tool/w32/isoiff/isoiff.dsp
+++ b/IsoLib/isoiff_tool/w32/isoiff/isoiff.dsp
@@ -620,6 +620,10 @@ SOURCE=..\..\src\BitRateAtom.c
 # End Source File
 # Begin Source File
 
+SOURCE=..\..\src\HumanReadableStreamDescriptionAtom.c
+# End Source File
+# Begin Source File
+
 SOURCE=..\..\src\AMRWPSpecificInfoAtom.c
 # End Source File
 # Begin Source File

--- a/IsoLib/libisomediafile/CMakeLists.txt
+++ b/IsoLib/libisomediafile/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(
     src/H263SpecificInfoAtom.c
     src/HandlerAtom.c
     src/HEVCConfigAtom.c
+    src/HumanReadableStreamDescriptionAtom.c
     src/LHEVCConfigAtom.c
     src/VVCConfigAtom.c
     src/VVCNALUConfigAtom.c

--- a/IsoLib/libisomediafile/linux/libisomediafile/Makefile
+++ b/IsoLib/libisomediafile/linux/libisomediafile/Makefile
@@ -158,6 +158,7 @@ sources = \
 	TextMetaSampleEntry.c \
 	XMLMetaSampleEntry.c \
 	BitRateAtom.c \
+	HumanReadableStreamDescriptionAtom.c \
 	AMRWPSpecificInfoAtom.c \
 	AMRSpecificInfoAtom.c \
 	H263SpecificInfoAtom.c \

--- a/IsoLib/libisomediafile/macosx/libisomediafile/Makefile
+++ b/IsoLib/libisomediafile/macosx/libisomediafile/Makefile
@@ -158,6 +158,7 @@ sources = \
 	TextMetaSampleEntry.c \
 	XMLMetaSampleEntry.c \
 	BitRateAtom.c \
+	HumanReadableStreamDescriptionAtom.c \
 	AMRWPSpecificInfoAtom.c \
 	AMRSpecificInfoAtom.c \
 	H263SpecificInfoAtom.c \

--- a/IsoLib/libisomediafile/src/HumanReadableStreamDescriptionAtom.c
+++ b/IsoLib/libisomediafile/src/HumanReadableStreamDescriptionAtom.c
@@ -1,0 +1,172 @@
+/*
+This software module was originally developed by Google LLC.
+in the course of development of MPEG-4.
+This software module is an implementation of a part of one or
+more MPEG-4 tools as specified by MPEG-4.
+ISO/IEC gives users of MPEG-4 free license to this
+software module or modifications thereof for use in hardware
+or software products claiming conformance to MPEG-4.
+Those intending to use this software module in hardware or software
+products are advised that its use may infringe existing patents.
+The original developer of this software module and his/her company,
+the subsequent editors and their companies, and ISO/IEC have no
+liability for use of this software module or modifications thereof
+in an implementation.
+Copyright is not released for non MPEG-4 conforming
+products. Google LLC retains full right to use the code for its own
+purpose, assign or donate the code to a third party and to
+inhibit third parties from using the code for non
+MPEG-4 conforming products.
+This copyright notice must be included in all copies or
+derivative works. Copyright (c) 2026.
+*/
+
+#include "MP4Atoms.h"
+#include <stdlib.h>
+#include <stdint.h>
+
+static void destroy(MP4AtomPtr s)
+{
+  MP4HumanReadableStreamDescriptionAtomPtr self;
+  self = (MP4HumanReadableStreamDescriptionAtomPtr)s;
+  if(self == NULL) return;
+
+  if(self->description)
+  {
+    free(self->description);
+    self->description = NULL;
+  }
+
+  if(self->super) self->super->destroy(s);
+}
+
+static MP4Err serialize(struct MP4Atom *s, char *buffer)
+{
+  MP4Err err                                    = MP4NoErr;
+  MP4HumanReadableStreamDescriptionAtomPtr self = (MP4HumanReadableStreamDescriptionAtomPtr)s;
+  size_t len;
+
+  err = MP4SerializeCommonBaseAtomFields(s, buffer);
+  if(err) goto bail;
+  buffer += self->bytesWritten;
+  assert(self->type == MP4HumanReadableStreamDescriptionAtomType);
+
+  len = strlen(self->description);
+  if(self->description == NULL || len == 0 || len >= UINT32_MAX - 1)
+  {
+    err = MP4BadParamErr;
+    goto bail;
+  }
+  /* Write description as null-terminated UTF-8 string */
+  PUTBYTES(self->description, (u32)len + 1); /* Include null terminator */
+
+  assert(self->bytesWritten == self->size);
+bail:
+  TEST_RETURN(err);
+
+  return err;
+}
+
+static MP4Err calculateSize(struct MP4Atom *s)
+{
+  MP4Err err;
+  MP4HumanReadableStreamDescriptionAtomPtr self = (MP4HumanReadableStreamDescriptionAtomPtr)s;
+  err                                           = MP4NoErr;
+
+  err = MP4CalculateBaseAtomFieldSize(s);
+  if(err) goto bail;
+
+  if(self->description == NULL || strlen(self->description) == 0)
+  {
+    err = MP4BadParamErr;
+    goto bail;
+  }
+  /* Add description size (null-terminated string) */
+  self->size += (u32)strlen(self->description) + 1; /* Including '\0' */
+
+bail:
+  TEST_RETURN(err);
+
+  return err;
+}
+
+static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStreamPtr inputStream)
+{
+  MP4Err err;
+  MP4HumanReadableStreamDescriptionAtomPtr self = (MP4HumanReadableStreamDescriptionAtomPtr)s;
+  s64 bytesToRead;
+  u32 nullPos;
+  u32 descLen;
+  u8 *buf = NULL;
+  u32 i;
+
+  if(self == NULL) BAILWITHERROR(MP4BadParamErr)
+  err = self->super->createFromInputStream(s, proto, (char *)inputStream);
+  if(err) goto bail;
+
+  /* Read all remaining bytes into a flat buffer, then split on the first null byte.
+   * Scanning byte-by-byte and "rewinding" by adjusting only bytesRead (while leaving
+   * the stream cursor in place) does not work — readData always reads from the current
+   * stream position. */
+  bytesToRead = (s64)(self->size - self->bytesRead);
+  if(bytesToRead < 0) BAILWITHERROR(MP4BadDataErr);
+
+  if(bytesToRead > 0)
+  {
+    buf = (u8 *)calloc((u32)bytesToRead, 1);
+    TESTMALLOC(buf);
+    err = inputStream->readData(inputStream, (u32)bytesToRead, (char *)buf, NULL);
+    if(err) goto bail;
+    self->bytesRead += (u32)bytesToRead;
+
+    /* Find the null terminator that ends the description field */
+    nullPos = (u32)bytesToRead; /* default: no null found */
+    for(i = 0; i < (u32)bytesToRead; i++)
+    {
+      if(buf[i] == 0)
+      {
+        nullPos = i;
+        break;
+      }
+    }
+
+    /* Description: bytes [0 .. nullPos] (including the null terminator) */
+    descLen           = nullPos + 1; /* length including null */
+    self->description = (char *)calloc(descLen, 1);
+    TESTMALLOC(self->description);
+    memcpy(self->description, buf, descLen);
+  }
+
+bail:
+  free(buf);
+  TEST_RETURN(err);
+  return err;
+}
+
+MP4Err
+MP4CreateHumanReadableStreamDescriptionAtom(MP4HumanReadableStreamDescriptionAtomPtr *outAtom)
+{
+  MP4Err err;
+  MP4HumanReadableStreamDescriptionAtomPtr self;
+
+  self = (MP4HumanReadableStreamDescriptionAtomPtr)calloc(
+    1, sizeof(MP4HumanReadableStreamDescriptionAtom));
+  TESTMALLOC(self);
+
+  err = MP4CreateBaseAtom((MP4AtomPtr)self);
+  if(err) goto bail;
+  self->type                  = MP4HumanReadableStreamDescriptionAtomType;
+  self->name                  = "HumanReadableStreamDescription";
+  self->createFromInputStream = (cisfunc)createFromInputStream;
+  self->destroy               = destroy;
+  self->calculateSize         = calculateSize;
+  self->serialize             = serialize;
+
+  self->description = NULL;
+
+  *outAtom = self;
+bail:
+  TEST_RETURN(err);
+
+  return err;
+}

--- a/IsoLib/libisomediafile/src/ISOMovies.h
+++ b/IsoLib/libisomediafile/src/ISOMovies.h
@@ -877,20 +877,16 @@ extern "C"
    * @ingroup SampleDescr
    *
    * Properly deserializes the handle returned by MP4GetMediaSampleDescription() and extracts
-   * the T.35 identifier bytes and optional description string. The caller is responsible for
-   * freeing *outIdentifier and *outDescription with free().
+   * the T.35 identifier bytes. The caller is responsible for freeing *outIdentifier with free().
    *
    * @param sampleEntryH  Handle containing the serialized 'it35' sample entry.
    * @param outIdentifier Output; receives a newly allocated copy of the t35_identifier bytes.
-   * @param outIdentifierSize Output; receives the number of bytes in *outIdentifier.
-   * @param outDescription Optional output; receives a newly allocated description string, or NULL
-   *                       if no description is present. Pass NULL to ignore.
+   * @param outIdentifierLength Output; receives the number of bytes in *outIdentifier.
    * @return MP4NoErr on success, MP4NotFoundErr if no identifier is present, MP4BadParamErr on
    *         invalid input.
    */
   ISO_EXTERN(ISOErr)
-  ISOGetT35SampleEntryFields(MP4Handle sampleEntryH, u8 **outIdentifier, u32 *outIdentifierSize,
-                             char **outDescription);
+  ISOGetT35SampleEntryFields(MP4Handle sampleEntryH, u8 **outIdentifier, u32 *outIdentifierLength);
 
   /*************************************************************************************************
    * VVC Sample descriptions

--- a/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
+++ b/IsoLib/libisomediafile/src/ISOSampleDescriptions.c
@@ -35,6 +35,7 @@
 #include "MP4DataHandler.h"
 #include <stdlib.h>
 #include <string.h>
+#include <memory.h>
 
 MP4Err MP4GetMediaESD(MP4Media theMedia, u32 index, MP4ES_DescriptorPtr *outESD,
                       u32 *outDataReferenceIndex);
@@ -46,43 +47,28 @@ MP4Err MP4ParseAtomUsingProtoList(MP4InputStreamPtr inputStream, u32 *protoList,
                                   MP4AtomPtr *outAtom);
 
 #ifdef ISMACrypt
-u32 MP4SampleEntryProtos[] = {MP4MPEGSampleEntryAtomType,
-                              MP4VisualSampleEntryAtomType,
-                              MP4AudioSampleEntryAtomType,
-                              MP4EncAudioSampleEntryAtomType,
-                              MP4EncVisualSampleEntryAtomType,
-                              MP4XMLMetaSampleEntryAtomType,
-                              MP4TextMetaSampleEntryAtomType,
-                              MP4AMRSampleEntryAtomType,
-                              MP4AWBSampleEntryAtomType,
-                              MP4AMRWPSampleEntryAtomType,
-                              MP4H263SampleEntryAtomType,
-                              MP4RestrictedVideoSampleEntryAtomType,
-                              MP4BoxedMetadataSampleEntryType,
-                              ISOAVCSampleEntryAtomType,
-                              ISOHEVCSampleEntryAtomType,
-                              ISOVVCSampleEntryAtomTypeInBand,
-                              ISOVVCSampleEntryAtomTypeOutOfBand,
-                              ISOVVCSubpicSampleEntryAtomType,
-                              0};
+u32 MP4SampleEntryProtos[] = {
+  MP4MPEGSampleEntryAtomType,      MP4VisualSampleEntryAtomType,
+  MP4AudioSampleEntryAtomType,     MP4EncAudioSampleEntryAtomType,
+  MP4EncVisualSampleEntryAtomType, MP4XMLMetaSampleEntryAtomType,
+  MP4TextMetaSampleEntryAtomType,  MP4AMRSampleEntryAtomType,
+  MP4AWBSampleEntryAtomType,       MP4AMRWPSampleEntryAtomType,
+  MP4H263SampleEntryAtomType,      MP4RestrictedVideoSampleEntryAtomType,
+  MP4BoxedMetadataSampleEntryType, MP4T35SampleGroupEntry,
+  ISOAVCSampleEntryAtomType,       ISOHEVCSampleEntryAtomType,
+  ISOVVCSampleEntryAtomTypeInBand, ISOVVCSampleEntryAtomTypeOutOfBand,
+  ISOVVCSubpicSampleEntryAtomType, 0};
 #else
-u32 MP4SampleEntryProtos[] = {MP4MPEGSampleEntryAtomType,
-                              MP4VisualSampleEntryAtomType,
-                              MP4AudioSampleEntryAtomType,
-                              MP4XMLMetaSampleEntryAtomType,
-                              MP4TextMetaSampleEntryAtomType,
-                              MP4AMRSampleEntryAtomType,
-                              MP4AWBSampleEntryAtomType,
-                              MP4AMRWPSampleEntryAtomType,
-                              MP4H263SampleEntryAtomType,
-                              MP4RestrictedVideoSampleEntryAtomType,
-                              MP4BoxedMetadataSampleEntryType,
-                              ISOAVCSampleEntryAtomType,
-                              ISOHEVCSampleEntryAtomType,
-                              ISOVVCSampleEntryAtomTypeInBand,
-                              ISOVVCSampleEntryAtomTypeOutOfBand,
-                              ISOVVCSubpicSampleEntryAtomType,
-                              0};
+u32 MP4SampleEntryProtos[] = {
+  MP4MPEGSampleEntryAtomType,      MP4VisualSampleEntryAtomType,
+  MP4AudioSampleEntryAtomType,     MP4XMLMetaSampleEntryAtomType,
+  MP4TextMetaSampleEntryAtomType,  MP4AMRSampleEntryAtomType,
+  MP4AWBSampleEntryAtomType,       MP4AMRWPSampleEntryAtomType,
+  MP4H263SampleEntryAtomType,      MP4RestrictedVideoSampleEntryAtomType,
+  MP4BoxedMetadataSampleEntryType, MP4T35SampleGroupEntry,
+  ISOAVCSampleEntryAtomType,       ISOHEVCSampleEntryAtomType,
+  ISOVVCSampleEntryAtomTypeInBand, ISOVVCSampleEntryAtomTypeOutOfBand,
+  ISOVVCSubpicSampleEntryAtomType, 0};
 #endif
 
 MP4Err sampleEntryHToAtomPtr(MP4Handle sampleEntryH, MP4AtomPtr *entryPtr, u32 defaultType)
@@ -443,6 +429,41 @@ MP4_EXTERN(MP4Err) ISOGetSampleDescriptionType(MP4Handle sampleEntryH, u32 *type
   if(err) goto bail;
 
   *type = entry->type;
+
+bail:
+  if(entry) entry->destroy((MP4AtomPtr)entry);
+  return err;
+}
+
+MP4_EXTERN(MP4Err)
+ISOGetFirstHumanReadableStreamDescription(MP4Handle sampleEntryH, char **description)
+{
+  MP4Err err                        = MP4NoErr;
+  MP4VisualSampleEntryAtomPtr entry = NULL;
+  u32 i;
+
+  if(sampleEntryH == NULL || description == NULL) BAILWITHERROR(MP4BadParamErr);
+
+  *description = NULL;
+
+  err = sampleEntryHToAtomPtr(sampleEntryH, (MP4AtomPtr *)&entry, MP4GenericSampleEntryAtomType);
+  if(err) goto bail;
+
+  for(i = 0; i < entry->ExtensionAtomList->entryCount; i++)
+  {
+    MP4AtomPtr atom;
+    MP4GetListEntry(entry->ExtensionAtomList, i, (char **)&atom);
+    if(atom->type == MP4HumanReadableStreamDescriptionAtomType)
+    {
+      const char *hrsd_description = ((MP4HumanReadableStreamDescriptionAtomPtr)atom)->description;
+      if(hrsd_description == NULL || hrsd_description[0] == '\0') continue;
+      assert(strlen(hrsd_description) + 1 <= atom->size - 8);
+      *description = (char *)calloc(strlen(hrsd_description) + 1, 1);
+      TESTMALLOC(*description);
+      strcpy(*description, hrsd_description);
+      break;
+    }
+  }
 
 bail:
   if(entry) entry->destroy((MP4AtomPtr)entry);
@@ -2503,11 +2524,12 @@ MP4_EXTERN(MP4Err)
 ISONewT35SampleDescription(MP4T35MetadataSampleEntryPtr *outSE, u32 dataReferenceIndex,
                            const char *t35_prefix_text)
 {
-  MP4Err err;
-  MP4T35MetadataSampleEntryPtr it35;
-  u8 *identifier     = NULL;
-  u32 identifierSize = 0;
-  char *description  = NULL;
+  MP4Err err                                    = MP4NoErr;
+  MP4T35MetadataSampleEntryPtr it35             = NULL;
+  MP4HumanReadableStreamDescriptionAtomPtr hrsd = NULL;
+  u8 *identifier                                = NULL;
+  u32 identifierSize                            = 0;
+  char *description                             = NULL;
 
   if(outSE == NULL || t35_prefix_text == NULL) BAILWITHERROR(MP4BadParamErr);
 
@@ -2520,18 +2542,34 @@ ISONewT35SampleDescription(MP4T35MetadataSampleEntryPtr *outSE, u32 dataReferenc
   if(err) goto bail;
   it35->dataReferenceIndex = dataReferenceIndex;
 
-  /* Set description and t35_identifier fields */
-  it35->description         = description;
-  it35->t35_identifier      = identifier;
-  it35->t35_identifier_size = identifierSize;
+  /* Set t35_identifier_length and t35_identifier fields */
+  it35->t35_identifier_length = identifierSize;
+  it35->t35_identifier        = identifier;
+  identifier                  = NULL; /* Transfer ownership */
+
+  if(description != NULL && description[0] != '\0')
+  {
+    err = MP4MakeLinkedList(&it35->ExtensionAtomList);
+    if(err) goto bail;
+
+    err = MP4CreateHumanReadableStreamDescriptionAtom(&hrsd);
+    if(err) goto bail;
+    hrsd->description = description;
+    description       = NULL; /* Transfer ownership */
+
+    err = MP4AddListEntry((void *)hrsd, it35->ExtensionAtomList);
+    if(err) goto bail;
+    hrsd = NULL; /* Transfer ownership */
+  }
 
   *outSE = it35;
-
-  return MP4NoErr;
+  it35   = NULL; /* Transfer ownership */
 
 bail:
   if(identifier) free(identifier);
   if(description) free(description);
+  if(hrsd) hrsd->destroy((MP4AtomPtr)hrsd);
+  if(it35) it35->destroy((MP4AtomPtr)it35);
   TEST_RETURN(err);
   return err;
 }
@@ -2608,8 +2646,7 @@ bail:
 }
 
 ISO_EXTERN(ISOErr)
-ISOGetT35SampleEntryFields(MP4Handle sampleEntryH, u8 **outIdentifier, u32 *outIdentifierSize,
-                           char **outDescription)
+ISOGetT35SampleEntryFields(MP4Handle sampleEntryH, u8 **outIdentifier, u32 *outIdentifierSize)
 {
   MP4Err err;
   MP4T35MetadataSampleEntryPtr it35 = NULL;
@@ -2619,25 +2656,17 @@ ISOGetT35SampleEntryFields(MP4Handle sampleEntryH, u8 **outIdentifier, u32 *outI
 
   *outIdentifier     = NULL;
   *outIdentifierSize = 0;
-  if(outDescription) *outDescription = NULL;
 
   err = sampleEntryHToAtomPtr(sampleEntryH, (MP4AtomPtr *)&it35, MP4T35MetadataSampleEntryType);
   if(err) goto bail;
 
-  if(it35->t35_identifier == NULL || it35->t35_identifier_size == 0) BAILWITHERROR(MP4NotFoundErr);
+  if(it35->t35_identifier == NULL || it35->t35_identifier_length == 0)
+    BAILWITHERROR(MP4NotFoundErr);
 
-  *outIdentifier = (u8 *)calloc(it35->t35_identifier_size, 1);
+  *outIdentifier = (u8 *)calloc(it35->t35_identifier_length, 1);
   TESTMALLOC(*outIdentifier);
-  memcpy(*outIdentifier, it35->t35_identifier, it35->t35_identifier_size);
-  *outIdentifierSize = it35->t35_identifier_size;
-
-  if(outDescription && it35->description && it35->description[0] != '\0')
-  {
-    u32 len         = (u32)strlen(it35->description) + 1;
-    *outDescription = (char *)calloc(len, 1);
-    TESTMALLOC(*outDescription);
-    memcpy(*outDescription, it35->description, len);
-  }
+  memcpy(*outIdentifier, it35->t35_identifier, it35->t35_identifier_length);
+  *outIdentifierSize = it35->t35_identifier_length;
 
 bail:
   if(it35) it35->destroy((MP4AtomPtr)it35);

--- a/IsoLib/libisomediafile/src/MP4Atoms.c
+++ b/IsoLib/libisomediafile/src/MP4Atoms.c
@@ -628,6 +628,11 @@ MP4Err MP4CreateAtom(u32 atomType, MP4AtomPtr *outAtom)
     err = MP4CreateBitRateAtom((MP4BitRateAtomPtr *)&newAtom);
     break;
 
+  case MP4HumanReadableStreamDescriptionAtomType:
+    err = MP4CreateHumanReadableStreamDescriptionAtom(
+      (MP4HumanReadableStreamDescriptionAtomPtr *)&newAtom);
+    break;
+
   case MP4ItemPropertiesAtomType:
     err = MP4CreateItemPropertiesAtom((MP4ItemPropertiesAtomPtr *)&newAtom);
     break;

--- a/IsoLib/libisomediafile/src/MP4Atoms.h
+++ b/IsoLib/libisomediafile/src/MP4Atoms.h
@@ -150,6 +150,7 @@ enum
   MP4H263SampleEntryAtomType                   = MP4_FOUR_CHAR_CODE('s', '2', '6', '3'),
   MP4H263SpecificInfoAtomType                  = MP4_FOUR_CHAR_CODE('d', '2', '6', '3'),
   MP4BitRateAtomType                           = MP4_FOUR_CHAR_CODE('b', 't', 'r', 't'),
+  MP4HumanReadableStreamDescriptionAtomType    = MP4_FOUR_CHAR_CODE('h', 'r', 's', 'd'),
   TGPPBitRateAtomType                          = MP4_FOUR_CHAR_CODE('b', 'i', 't', 'r'),
   MP4OriginalFormatAtomType                    = MP4_FOUR_CHAR_CODE('f', 'r', 'm', 'a'),
   MP4SchemeTypeAtomType                        = MP4_FOUR_CHAR_CODE('s', 'c', 'h', 'm'),
@@ -868,9 +869,8 @@ typedef struct MP4T35MetadataSampleEntry
 {
   MP4_BASE_ATOM
   COMMON_SAMPLE_ENTRY_FIELDS
-  char *description;       /* UTF-8 string, '\0' if empty */
-  u8 *t35_identifier;      /* Variable length byte array */
-  u32 t35_identifier_size; /* Size of t35_identifier in bytes */
+  u32 t35_identifier_length; /* Size of t35_identifier in bytes */
+  u8 *t35_identifier;        /* Variable-length byte array */
 } MP4T35MetadataSampleEntry, *MP4T35MetadataSampleEntryPtr;
 
 typedef struct MP4VisualSampleEntryAtom
@@ -1103,6 +1103,13 @@ typedef struct MP4BitRateAtom
   u32 max_bitrate; /* uint(32) */
 
 } MP4BitRateAtom, *MP4BitRateAtomPtr;
+
+typedef struct MP4HumanReadableStreamDescriptionAtom
+{
+  MP4_BASE_ATOM
+  char *description; /* UTF-8 string */
+
+} MP4HumanReadableStreamDescriptionAtom, *MP4HumanReadableStreamDescriptionAtomPtr;
 
 typedef struct MP4SampleDescriptionAtom
 {
@@ -2454,6 +2461,8 @@ MP4Err MP4CreateAMRSpecificInfoAtom(MP4AMRSpecificInfoAtomPtr *outAtom);
 MP4Err MP4CreateAMRWPSpecificInfoAtom(MP4AMRWPSpecificInfoAtomPtr *outAtom);
 MP4Err MP4CreateH263SpecificInfoAtom(MP4H263SpecificInfoAtomPtr *outAtom);
 MP4Err MP4CreateBitRateAtom(MP4BitRateAtomPtr *outAtom);
+MP4Err
+MP4CreateHumanReadableStreamDescriptionAtom(MP4HumanReadableStreamDescriptionAtomPtr *outAtom);
 
 MP4Err MP4CreateVisualMediaHeaderAtom(MP4VolumetricVisualMediaHeaderAtomPtr *outAtom);
 

--- a/IsoLib/libisomediafile/src/MP4Movies.h
+++ b/IsoLib/libisomediafile/src/MP4Movies.h
@@ -2179,6 +2179,14 @@ extern "C"
    * @ingroup SampleDescr
    */
   MP4_EXTERN(MP4Err) ISOGetSampleDescriptionType(MP4Handle sampleEntryH, u32 *type);
+  /**
+   * @brief This function returns the first human-readable description of a stream.
+   *
+   * @attention The caller is responsible for freeing *description with free().
+   * @ingroup SampleDescr
+   */
+  MP4_EXTERN(MP4Err)
+  ISOGetFirstHumanReadableStreamDescription(MP4Handle sampleEntryH, char **description);
 
   /**
    * @brief This starts a new movie fragment.

--- a/IsoLib/libisomediafile/src/T35MetadataSampleEntry.c
+++ b/IsoLib/libisomediafile/src/T35MetadataSampleEntry.c
@@ -18,14 +18,9 @@
 
 static void destroy(MP4AtomPtr s)
 {
+  MP4Err err                        = MP4NoErr;
   MP4T35MetadataSampleEntryPtr self = (MP4T35MetadataSampleEntryPtr)s;
   if(self == NULL) return;
-
-  if(self->description)
-  {
-    free(self->description);
-    self->description = NULL;
-  }
 
   if(self->t35_identifier)
   {
@@ -33,7 +28,11 @@ static void destroy(MP4AtomPtr s)
     self->t35_identifier = NULL;
   }
 
+  DESTROY_ATOM_LIST_F(ExtensionAtomList);
   if(self->super) self->super->destroy(s);
+bail:
+  TEST_RETURN(err);
+  return;
 }
 
 static MP4Err serialize(struct MP4Atom *s, char *buffer)
@@ -48,25 +47,20 @@ static MP4Err serialize(struct MP4Atom *s, char *buffer)
   PUTBYTES(self->reserved, 6);
   PUT16(dataReferenceIndex);
 
-  /* Write description as null-terminated UTF-8 string */
-  if(self->description != NULL)
+  if(self->t35_identifier_length < 1 || self->t35_identifier_length > 255 ||
+     self->t35_identifier == NULL)
   {
-    u32 descLen = (u32)strlen(self->description) + 1; /* Include null terminator */
-    PUTBYTES(self->description, descLen);
+    err = MP4BadParamErr;
+    goto bail;
   }
-  else
-  {
-    /* Empty description: just write '\0' */
-    u8 nullByte = 0;
-    PUT8_V(nullByte);
-  }
+
+  /* Write t35_identifier_length */
+  PUT8(t35_identifier_length);
 
   /* Write t35_identifier byte array */
-  if(self->t35_identifier != NULL && self->t35_identifier_size > 0)
-  {
-    PUTBYTES(self->t35_identifier, self->t35_identifier_size);
-  }
+  PUTBYTES(self->t35_identifier, self->t35_identifier_length);
 
+  SERIALIZE_ATOM_LIST(ExtensionAtomList);
   assert(self->bytesWritten == self->size);
 bail:
   TEST_RETURN(err);
@@ -83,22 +77,19 @@ static MP4Err calculateSize(struct MP4Atom *s)
 
   self->size += (6 + 2); /* reserved + dataReferenceIndex */
 
-  /* Add description size (null-terminated string) */
-  if(self->description != NULL)
+  if(self->t35_identifier_length < 1 || self->t35_identifier_length > 255 ||
+     self->t35_identifier == NULL)
   {
-    self->size += (u32)strlen(self->description) + 1;
-  }
-  else
-  {
-    self->size += 1; /* Just '\0' */
+    err = MP4BadParamErr;
+    goto bail;
   }
 
+  /* Add t35_identifier_length size */
+  self->size += 1;
   /* Add t35_identifier size */
-  if(self->t35_identifier != NULL)
-  {
-    self->size += self->t35_identifier_size;
-  }
+  self->size += self->t35_identifier_length;
 
+  ADD_ATOM_LIST_SIZE(ExtensionAtomList);
 bail:
   TEST_RETURN(err);
   return err;
@@ -108,10 +99,8 @@ static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
 {
   MP4Err err;
   MP4T35MetadataSampleEntryPtr self = (MP4T35MetadataSampleEntryPtr)s;
-  s64 bytesToRead;
-  u8 *buf = NULL;
-  u32 i;
 
+  err = MP4NoErr;
   if(self == NULL) BAILWITHERROR(MP4BadParamErr)
   err = self->super->createFromInputStream(s, proto, (char *)inputStream);
   if(err) goto bail;
@@ -119,64 +108,25 @@ static MP4Err createFromInputStream(MP4AtomPtr s, MP4AtomPtr proto, MP4InputStre
   GETBYTES(6, reserved);
   GET16(dataReferenceIndex);
 
-  /* Read all remaining bytes into a flat buffer, then split on the first null byte.
-   * Scanning byte-by-byte and "rewinding" by adjusting only bytesRead (while leaving
-   * the stream cursor in place) does not work — readData always reads from the current
-   * stream position. */
-  bytesToRead = (s64)(self->size - self->bytesRead);
-  if(bytesToRead < 0) BAILWITHERROR(MP4BadDataErr);
+  /* Read t35_identifier_length */
+  err = inputStream->read8(inputStream, &self->t35_identifier_length, NULL);
+  if(err) goto bail;
+  ++self->bytesRead;
+  if(self->t35_identifier_length == 0) BAILWITHERROR(MP4BadDataErr);
+  if(self->t35_identifier_length > self->size - self->bytesRead) BAILWITHERROR(MP4BadDataErr);
 
-  if(bytesToRead > 0)
-  {
-    buf = (u8 *)calloc((u32)bytesToRead, 1);
-    TESTMALLOC(buf);
-    err = inputStream->readData(inputStream, (u32)bytesToRead, (char *)buf, NULL);
-    if(err) goto bail;
-    self->bytesRead += (u32)bytesToRead;
+  /* Read t35_identifier */
+  self->t35_identifier = (u8 *)calloc(self->t35_identifier_length, 1);
+  TESTMALLOC(self->t35_identifier);
+  err = inputStream->readData(inputStream, self->t35_identifier_length,
+                              (char *)self->t35_identifier, NULL);
+  if(err) goto bail;
+  self->bytesRead += self->t35_identifier_length;
 
-    /* Find the null terminator that ends the description field */
-    u32 nullPos = (u32)bytesToRead; /* default: no null found */
-    for(i = 0; i < (u32)bytesToRead; i++)
-    {
-      if(buf[i] == 0)
-      {
-        nullPos = i;
-        break;
-      }
-    }
-
-    /* Description: bytes [0 .. nullPos] (including the null terminator) */
-    u32 descLen       = nullPos + 1; /* length including null */
-    self->description = (char *)calloc(descLen, 1);
-    TESTMALLOC(self->description);
-    memcpy(self->description, buf, descLen);
-
-    /* t35_identifier: bytes after the null terminator */
-    /* TODO: the length of t35_identifier is currently inferred as "all bytes remaining in the
-     * box after the description null terminator", which prevents any optional boxes (e.g.
-     * BitRateBox) from following it and makes the format non-extensible.
-     * This must be resolved at the next MPEG meeting, either by:
-     *   (a) preceding t35_identifier with an explicit length field (e.g. unsigned int(8)), or
-     *   (b) wrapping description and t35_identifier in their own child boxes (e.g. 'hrsd' for
-     *       the human-readable description as already proposed in the amendment text).
-     * Until then, optional boxes MUST NOT be appended after t35_identifier. */
-    u32 identStart = descLen;
-    if(identStart < (u32)bytesToRead)
-    {
-      self->t35_identifier_size = (u32)bytesToRead - identStart;
-      self->t35_identifier      = (u8 *)calloc(self->t35_identifier_size, 1);
-      TESTMALLOC(self->t35_identifier);
-      memcpy(self->t35_identifier, buf + identStart, self->t35_identifier_size);
-    }
-
-    free(buf);
-    buf = NULL;
-  }
-
+  GETATOM_LIST(ExtensionAtomList);
   if(self->bytesRead != self->size) BAILWITHERROR(MP4BadDataErr)
 
 bail:
-  free(buf);
   TEST_RETURN(err);
   return err;
 }
@@ -202,9 +152,12 @@ MP4Err MP4CreateT35MetadataSampleEntry(MP4T35MetadataSampleEntryPtr *outAtom)
   self->dataReferenceIndex = 1;
   memset(self->reserved, 0, 6);
 
-  self->description         = NULL;
-  self->t35_identifier      = NULL;
-  self->t35_identifier_size = 0;
+  self->t35_identifier_length = 0;
+  self->t35_identifier        = NULL;
+
+  // Typically for MP4HumanReadableStreamDescriptionAtom.
+  err = MP4MakeLinkedList(&self->ExtensionAtomList);
+  if(err) goto bail;
 
   *outAtom = self;
 bail:

--- a/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.dsp
+++ b/IsoLib/libisomediafile/w32/libisomediafile/libisomedia.dsp
@@ -632,6 +632,10 @@ SOURCE=..\..\src\BitRateAtom.c
 # End Source File
 # Begin Source File
 
+SOURCE=..\..\src\HumanReadableStreamDescriptionAtom.c
+# End Source File
+# Begin Source File
+
 SOURCE=..\..\src\AMRWPSpecificInfoAtom.c
 # End Source File
 # Begin Source File

--- a/IsoLib/t35_tool/extraction/DedicatedIt35Extractor.cpp
+++ b/IsoLib/t35_tool/extraction/DedicatedIt35Extractor.cpp
@@ -83,19 +83,30 @@ static MP4Err findIt35MetadataTrack(MP4Movie moov, const std::string &t35PrefixS
 
     LOG_INFO("Found IT35 track with ID {}", trackID);
 
-    // Read t35_identifier and description from the serialized sample entry handle
-    u8 *identifier     = nullptr;
-    u32 identifierSize = 0;
-    char *description  = nullptr;
+    u8 *identifier       = nullptr;
+    u32 identifierLength = 0;
+    char *description    = NULL;
 
-    MP4Err readErr =
-      ISOGetT35SampleEntryFields(sampleEntryH, &identifier, &identifierSize, &description);
+    // Read t35_identifier from the serialized sample entry handle
+    MP4Err readErr = ISOGetT35SampleEntryFields(sampleEntryH, &identifier, &identifierLength);
+
+    // Read an optional description from a child
+    // HumanReadableStreamDescription in the sample entry
+    MP4Err hrsdErr = ISOGetFirstHumanReadableStreamDescription(sampleEntryH, &description);
+
     MP4DisposeHandle(sampleEntryH);
     sampleEntryH = nullptr;
 
-    if(readErr || identifier == nullptr || identifierSize == 0)
+    if(readErr || identifier == nullptr || identifierLength == 0)
     {
       LOG_WARN("Could not read t35_identifier from IT35 sample entry");
+      free(identifier);
+      free(description);
+      continue;
+    }
+    if(hrsdErr)
+    {
+      LOG_WARN("Could not read HumanReadableStreamDescription");
       free(identifier);
       free(description);
       continue;
@@ -103,8 +114,8 @@ static MP4Err findIt35MetadataTrack(MP4Movie moov, const std::string &t35PrefixS
 
     // Convert t35_identifier bytes to hex string
     std::string hexStr;
-    hexStr.reserve(identifierSize * 2);
-    for(u32 j = 0; j < identifierSize; j++)
+    hexStr.reserve(identifierLength * 2);
+    for(u32 j = 0; j < identifierLength; j++)
     {
       char buf[3];
       snprintf(buf, sizeof(buf), "%02X", identifier[j]);
@@ -121,7 +132,7 @@ static MP4Err findIt35MetadataTrack(MP4Movie moov, const std::string &t35PrefixS
     }
 
     LOG_DEBUG("Parsed 'it35' sample entry: identifier={} ({} bytes), description='{}'", hexStr,
-              identifierSize, (description && description[0] != '\0') ? description : "<empty>");
+              identifierLength, (description && description[0] != '\0') ? description : "<empty>");
     free(description);
 
     // Parse both prefixes to compare hex part only

--- a/IsoLib/t35_tool/injection/MebxMe4cStrategy.cpp
+++ b/IsoLib/t35_tool/injection/MebxMe4cStrategy.cpp
@@ -294,22 +294,6 @@ static MP4Err fourCCToHandle(u32 fourCC, MP4Handle *outHandle)
   return MP4NoErr;
 }
 
-// Helper: Convert string to handle (as text, not hex)
-static MP4Err stringToHandle(const std::string &input, MP4Handle *outHandle)
-{
-  MP4Err err = MP4NoErr;
-  *outHandle = nullptr;
-
-  // Copy input string as text
-  u32 byteCount = static_cast<u32>(input.size());
-  err           = MP4NewHandle(byteCount, outHandle);
-  if(err) return err;
-
-  std::memcpy(**outHandle, input.data(), byteCount);
-
-  return MP4NoErr;
-}
-
 bool MebxMe4cStrategy::isApplicable(const MetadataMap &items, const InjectionConfig &config,
                                     std::string &reason) const
 {


### PR DESCRIPTION
The following succeeds:

```sh
t35_tool inject \
  --source "json-manifest:TestData/t35_tool/test_manifest.json" \
  --method "dedicated-it35" \
  --t35-prefix "B500900001:SMPTE-ST2094-50" \
  "TestData/isobmff/01_simple.mp4" \
  "/tmp/test_out.mp4"
t35_tool extract \
  --method "dedicated-it35" \
  "/tmp/test_out.mp4" \
  "/tmp/"
```


https://github.com/user-attachments/assets/fb128503-d246-4cdc-bbd5-1896aa7b3af5

