### PR TITLE
Add "bitstream" injection method to t35_tool

### DIFF
--- a/IsoLib/libisomediafile/src/MP4Media.c
+++ b/IsoLib/libisomediafile/src/MP4Media.c
@@ -1924,6 +1924,147 @@ bail:
 }
 
 MP4_EXTERN(MP4Err)
+MP4UpdateMediaSample(MP4Movie theMovie, MP4Media theMedia, u32 sampleNumber, MP4Handle sampleH,
+                     u32 sampleSize)
+{
+  MP4Err err;
+  MP4MediaInformationAtomPtr minf;
+  MP4SampleTableAtomPtr stbl;
+  MP4SampleSizeAtomPtr stsz;
+  MP4SampleToChunkAtomPtr stsc;
+  MP4ChunkOffsetAtomPtr stco;
+
+  MP4PrivateMovieRecordPtr movie = (MP4PrivateMovieRecordPtr)theMovie;
+  MP4MediaDataAtomPtr mdat;
+
+  u32 chunkNumber;
+  u32 sampleDescriptionIndex;
+  u32 firstSampleNumberInChunk;
+  u32 sampleOffsetWithinChunk;
+  u32 oldSize;
+  u64 chunkOffset;
+  u64 computedOffset;
+  s32 deltaSize;
+
+  err = MP4NoErr;
+  if((theMovie == NULL) || (theMedia == NULL) || (sampleH == NULL))
+  {
+    BAILWITHERROR(MP4BadParamErr);
+  }
+
+  mdat = (MP4MediaDataAtomPtr)movie->mdat;
+  if((mdat == NULL) || (mdat->data == NULL))
+  {
+    BAILWITHERROR(MP4NotImplementedErr);
+  }
+
+  minf = (MP4MediaInformationAtomPtr)((MP4MediaAtomPtr)theMedia)->information;
+  if(minf == NULL) BAILWITHERROR(MP4InvalidMediaErr);
+
+  stbl = (MP4SampleTableAtomPtr)minf->sampleTable;
+  if(stbl == NULL) BAILWITHERROR(MP4InvalidMediaErr);
+
+  stsz = (MP4SampleSizeAtomPtr)stbl->SampleSize;
+  stsc = (MP4SampleToChunkAtomPtr)stbl->SampleToChunk;
+  stco = (MP4ChunkOffsetAtomPtr)stbl->ChunkOffset;
+
+  if((stsz == NULL) || (stsc == NULL) || (stco == NULL)) BAILWITHERROR(MP4InvalidMediaErr);
+
+  /* get chunk and offset within chunk */
+  err = stsc->lookupSample(stbl->SampleToChunk, sampleNumber, &chunkNumber, &sampleDescriptionIndex,
+                           &firstSampleNumberInChunk);
+  if(err) goto bail;
+
+  err = stsz->getSampleSizeAndOffset(stbl->SampleSize, sampleNumber, &oldSize,
+                                     firstSampleNumberInChunk, &sampleOffsetWithinChunk);
+  if(err) goto bail;
+
+  err = stco->getChunkOffset(stbl->ChunkOffset, chunkNumber, &chunkOffset);
+  if(err) goto bail;
+
+  computedOffset = chunkOffset + sampleOffsetWithinChunk;
+  deltaSize      = sampleSize - oldSize;
+
+  if(deltaSize != 0)
+  {
+    /* Shift data in mdat */
+    u64 mdatOffset = computedOffset;
+    char *newData;
+
+    newData = (char *)realloc(mdat->data, mdat->dataSize + deltaSize);
+    if(newData == NULL) BAILWITHERROR(MP4NoMemoryErr);
+    mdat->data = newData;
+
+    memmove(mdat->data + mdatOffset + sampleSize, mdat->data + mdatOffset + oldSize,
+            mdat->dataSize - (mdatOffset + oldSize));
+
+    mdat->dataSize += deltaSize;
+
+    /* Update sample size in stsz */
+    if(stsz->sampleSize != 0)
+    {
+      u32 i;
+      stsz->sizes = (u32 *)calloc(stsz->sampleCount, sizeof(u32));
+      if(stsz->sizes == NULL) BAILWITHERROR(MP4NoMemoryErr);
+      for(i = 0; i < stsz->sampleCount; i++)
+        stsz->sizes[i] = stsz->sampleSize;
+      stsz->sampleSize = 0;
+    }
+    stsz->sizes[sampleNumber - 1] = sampleSize;
+
+    /* Update chunk offsets directly for all tracks */
+    {
+      MP4MovieAtomPtr moov = (MP4MovieAtomPtr)movie->moovAtomPtr;
+      u32 trackCount;
+      u32 i;
+      err = MP4GetListEntryCount(moov->trackList, &trackCount);
+      if(err) goto bail;
+
+      for(i = 0; i < trackCount; i++)
+      {
+        MP4TrackAtomPtr trak;
+        err = MP4GetListEntry(moov->trackList, i, (char **)&trak);
+        if(err) goto bail;
+        if(trak && trak->trackMedia)
+        {
+          MP4MediaAtomPtr media = (MP4MediaAtomPtr)trak->trackMedia;
+          if(media->information)
+          {
+            MP4MediaInformationAtomPtr minf_ptr = (MP4MediaInformationAtomPtr)media->information;
+            if(minf_ptr->sampleTable)
+            {
+              MP4SampleTableAtomPtr stbl_ptr = (MP4SampleTableAtomPtr)minf_ptr->sampleTable;
+              MP4ChunkOffsetAtomPtr stco_ptr = (MP4ChunkOffsetAtomPtr)stbl_ptr->ChunkOffset;
+
+              if(stco_ptr)
+              {
+                u32 j;
+                for(j = 0; j < stco_ptr->entryCount; j++)
+                {
+                  if(stco_ptr->offsets[j] >= computedOffset + oldSize)
+                  {
+                    stco_ptr->offsets[j] += deltaSize;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    if(err) goto bail;
+  }
+
+  /* Copy new data */
+  u64 mdatOffset = computedOffset;
+  memcpy(mdat->data + mdatOffset, *sampleH, sampleSize);
+
+bail:
+  TEST_RETURN(err);
+  return err;
+}
+
+MP4_EXTERN(MP4Err)
 MP4GetIndMediaSampleReference(MP4Media theMedia, u32 sampleNumber, u32 *outOffset, u32 *outSize,
                               u32 *outDuration, u32 *outSampleFlags, u32 *outSampleDescIndex,
                               MP4Handle sampleDesc)

--- a/IsoLib/libisomediafile/src/MP4Movies.h
+++ b/IsoLib/libisomediafile/src/MP4Movies.h
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @file MP4Movies.h
  * @brief API
  * @version 0.1
@@ -1075,6 +1075,19 @@ extern "C"
   MP4AddMediaSamples(MP4Media media, MP4Handle sampleH, u32 sampleCount, MP4Handle durationsH,
                      MP4Handle sizesH, MP4Handle sampleEntryH, MP4Handle decodingOffsetsH,
                      MP4Handle syncSamplesH);
+
+  /**
+   * @brief Update a sample in the media.
+   *
+   * @param media input media object
+   * @param sampleNumber 1-based index of the sample to update
+   * @param sampleH handle containing the new data
+   * @param sampleSize new size of the sample
+   * @return MP4Err error code
+   */
+  MP4_EXTERN(MP4Err)
+  MP4UpdateMediaSample(MP4Movie theMovie, MP4Media media, u32 sampleNumber, MP4Handle sampleH,
+                       u32 sampleSize);
   /**
    * @brief Add media samples by reference with padding bits
    *

--- a/IsoLib/t35_tool/CMakeLists.txt
+++ b/IsoLib/t35_tool/CMakeLists.txt
@@ -74,6 +74,7 @@ add_executable(
   injection/MebxMe4cStrategy.cpp
   injection/DedicatedIt35Strategy.cpp
   injection/SampleGroupStrategy.cpp
+  injection/BitstreamStrategy.cpp
   extraction/ExtractionStrategy.cpp
   extraction/MebxMe4cExtractor.cpp
   extraction/DedicatedIt35Extractor.cpp

--- a/IsoLib/t35_tool/injection/BitstreamStrategy.cpp
+++ b/IsoLib/t35_tool/injection/BitstreamStrategy.cpp
@@ -1,0 +1,277 @@
+#include "BitstreamStrategy.hpp"
+#include "StrategyHelpers.hpp"
+#include "../common/Logger.hpp"
+#include <cstdlib>
+
+extern "C"
+{
+#include "MP4Movies.h"
+}
+
+#include <vector>
+#include <cstring>
+#include <algorithm>
+
+namespace t35
+{
+
+bool BitstreamStrategy::isApplicable(const MetadataMap &items, const InjectionConfig &config,
+                                     std::string &reason) const
+{
+  if(!config.movie)
+  {
+    reason = "No movie provided";
+    return false;
+  }
+
+  if(items.empty())
+  {
+    reason = "No metadata items to inject";
+    return false;
+  }
+
+  // Find video track
+  MP4Track trakV = nullptr;
+  MP4Err err     = findFirstVideoTrack(config.movie, &trakV);
+  if(err || !trakV)
+  {
+    reason = "No video track found";
+    return false;
+  }
+
+  // Get media
+  MP4Media mediaV = nullptr;
+  err             = MP4GetTrackMedia(trakV, &mediaV);
+  if(err || !mediaV)
+  {
+    reason = "Failed to get video media";
+    return false;
+  }
+
+  // Get sample description
+  MP4Handle sampleDescH = nullptr;
+  MP4NewHandle(0, &sampleDescH);
+  u32 dataRefIndex = 0;
+  err              = MP4GetMediaSampleDescription(mediaV, 1, sampleDescH, &dataRefIndex);
+  if(err)
+  {
+    reason = "Failed to get sample description";
+    MP4DisposeHandle(sampleDescH);
+    return false;
+  }
+
+  u32 type = 0;
+  ISOGetSampleDescriptionType(sampleDescH, &type);
+  MP4DisposeHandle(sampleDescH);
+
+  if(type != MP4_FOUR_CHAR_CODE('a', 'v', '0', '1') &&
+     type != MP4_FOUR_CHAR_CODE('h', 'v', 'c', '1') &&
+     type != MP4_FOUR_CHAR_CODE('h', 'e', 'v', '1'))
+  {
+    reason = "Only AV1 and HEVC bitstreams are supported";
+    return false;
+  }
+
+  return true;
+}
+
+MP4Err BitstreamStrategy::inject(const InjectionConfig &config, const MetadataMap &items,
+                                 const T35Prefix &prefix)
+{
+  LOG_INFO("Injecting metadata into video bitstream");
+  LOG_INFO("Using T.35 prefix: {}", prefix.toString());
+
+  MP4Err err            = MP4NoErr;
+  MP4Track trakV        = nullptr;
+  MP4Media mediaV       = nullptr;
+  u32 sampleCount       = 0;
+  u32 type              = 0;
+  MP4Handle sampleDescH = nullptr;
+
+  err = findFirstVideoTrack(config.movie, &trakV);
+  if(err) return err;
+
+  err = MP4GetTrackMedia(trakV, &mediaV);
+  if(err) return err;
+
+  err = MP4GetMediaSampleCount(mediaV, &sampleCount);
+  if(err) return err;
+
+  // Build mapping from composition frame to decoding sample index
+  struct SampleTimeInfo
+  {
+    u32 decodingIndex; // 1-based
+    u64 cts;
+  };
+  std::vector<SampleTimeInfo> sampleTimes;
+  sampleTimes.reserve(sampleCount);
+
+  for(u32 i = 1; i <= sampleCount; ++i)
+  {
+    MP4Handle sampleH = nullptr;
+    u32 outSize, outSampleFlags, outSampleDescIndex;
+    u64 outDTS, outDuration;
+    s32 outCTSOffset;
+
+    MP4NewHandle(0, &sampleH);
+    err = MP4GetIndMediaSample(mediaV, i, sampleH, &outSize, &outDTS, &outCTSOffset, &outDuration,
+                               &outSampleFlags, &outSampleDescIndex);
+    if(err)
+    {
+      if(sampleH) MP4DisposeHandle(sampleH);
+      return err;
+    }
+
+    u64 cts = outDTS;
+    if(outSampleFlags & MP4MediaSampleHasCTSOffset)
+    {
+      cts = static_cast<u64>(static_cast<s64>(outDTS) + outCTSOffset);
+    }
+    sampleTimes.push_back({i, cts});
+
+    if(sampleH) MP4DisposeHandle(sampleH);
+  }
+
+  // Sort by CTS to get composition order
+  std::sort(sampleTimes.begin(), sampleTimes.end(),
+            [](const SampleTimeInfo &a, const SampleTimeInfo &b) { return a.cts < b.cts; });
+
+  // Map decoding index (1-based) to MetadataItem
+  std::map<u32, MetadataItem> decodingIndexToMetadata;
+  for(u32 compIdx = 0; compIdx < sampleTimes.size(); ++compIdx)
+  {
+    auto it = items.find(compIdx);
+    if(it != items.end())
+    {
+      decodingIndexToMetadata[sampleTimes[compIdx].decodingIndex] = it->second;
+    }
+  }
+
+  MP4NewHandle(0, &sampleDescH);
+  u32 dataRefIndex = 0;
+  err              = MP4GetMediaSampleDescription(mediaV, 1, sampleDescH, &dataRefIndex);
+  if(err)
+  {
+    MP4DisposeHandle(sampleDescH);
+    return err;
+  }
+
+  ISOGetSampleDescriptionType(sampleDescH, &type);
+  MP4DisposeHandle(sampleDescH);
+
+  bool isAV1  = (type == MP4_FOUR_CHAR_CODE('a', 'v', '0', '1'));
+  bool isHEVC = (type == MP4_FOUR_CHAR_CODE('h', 'v', 'c', '1') ||
+                 type == MP4_FOUR_CHAR_CODE('h', 'e', 'v', '1'));
+
+  LOG_INFO("Bitstream codec: {}", isAV1 ? "AV1" : "HEVC");
+
+  for(u32 i = 1; i <= sampleCount; ++i)
+  {
+    MP4Handle sampleH = nullptr;
+    u32 outSize, outSampleFlags, outSampleDescIndex;
+    u64 outDTS;
+    s32 outCTSOffset;
+    u64 outDuration;
+
+    MP4NewHandle(0, &sampleH);
+    err = MP4GetIndMediaSample(mediaV, i, sampleH, &outSize, &outDTS, &outCTSOffset, &outDuration,
+                               &outSampleFlags, &outSampleDescIndex);
+    if(err)
+    {
+      MP4DisposeHandle(sampleH);
+      return err;
+    }
+
+    auto it = decodingIndexToMetadata.find(i);
+    if(it != decodingIndexToMetadata.end())
+    {
+      const MetadataItem &item = it->second;
+      LOG_DEBUG("Injecting metadata into sample {} (mapped from composition frame {})", i,
+                item.frame_start);
+
+      std::vector<uint8_t> t35PrefixBytes = T35Prefix(config.t35Prefix).toBytes();
+
+      MP4Handle newSampleH = nullptr;
+
+      if(isAV1)
+      {
+        std::vector<uint8_t> obu;
+        obu.push_back(0x2A); // Forbidden=0, Type=5(METADATA), Ext=0, HasSize=1, Reserved=0
+
+        // Size includes: metadata_type (1) + t35PrefixBytes + payload + trailing byte (1)
+        uint64_t size = 1 + t35PrefixBytes.size() + item.payload.size() + 1;
+        while(size >= 0x80)
+        {
+          obu.push_back(static_cast<uint8_t>((size & 0x7F) | 0x80));
+          size >>= 7;
+        }
+        obu.push_back(static_cast<uint8_t>(size));
+
+        obu.push_back(0x04); // OBU type / metadata_type = 4 (OBU_METADATA_TYPE_ITUT_T35)
+        obu.insert(obu.end(), t35PrefixBytes.begin(), t35PrefixBytes.end());
+        obu.insert(obu.end(), item.payload.begin(), item.payload.end());
+        obu.push_back(0x80); // trailing byte
+
+        u32 newSize = outSize + obu.size();
+        MP4NewHandle(newSize, &newSampleH);
+
+        char *newSampleData = *newSampleH;
+        std::memcpy(newSampleData, obu.data(), obu.size());
+        std::memcpy(newSampleData + obu.size(), *sampleH, outSize);
+      }
+      else if(isHEVC)
+      {
+        std::vector<uint8_t> nalu;
+        nalu.push_back(0x4E); // nal_unit_type = 39 (PREFIX_SEI_NUT), layer_id = 0
+        nalu.push_back(0x01); // temporal_id_plus1 = 1
+
+        nalu.push_back(4); // payload_type = 4 (user_data_registered_itu_t_t35)
+
+        // Size includes: t35PrefixBytes + payload + trailing byte (1)
+        size_t size = t35PrefixBytes.size() + item.payload.size() + 1;
+        while(size >= 255)
+        {
+          nalu.push_back(0xFF);
+          size -= 255;
+        }
+        nalu.push_back(static_cast<uint8_t>(size));
+
+        nalu.insert(nalu.end(), t35PrefixBytes.begin(), t35PrefixBytes.end());
+        nalu.insert(nalu.end(), item.payload.begin(), item.payload.end());
+        nalu.push_back(0x80); // trailing byte
+
+        u32 naluSize = nalu.size();
+        std::vector<uint8_t> lengthPrefixed;
+        lengthPrefixed.push_back((naluSize >> 24) & 0xFF);
+        lengthPrefixed.push_back((naluSize >> 16) & 0xFF);
+        lengthPrefixed.push_back((naluSize >> 8) & 0xFF);
+        lengthPrefixed.push_back(naluSize & 0xFF);
+        lengthPrefixed.insert(lengthPrefixed.end(), nalu.begin(), nalu.end());
+
+        u32 newSize = outSize + lengthPrefixed.size();
+        MP4NewHandle(newSize, &newSampleH);
+
+        char *newSampleData = *newSampleH;
+        std::memcpy(newSampleData, lengthPrefixed.data(), lengthPrefixed.size());
+        std::memcpy(newSampleData + lengthPrefixed.size(), *sampleH, outSize);
+      }
+
+      u32 actualNewSize = 0;
+      MP4GetHandleSize(newSampleH, &actualNewSize);
+
+      err = MP4UpdateMediaSample(config.movie, mediaV, i, newSampleH, actualNewSize);
+      MP4DisposeHandle(newSampleH);
+      if(err)
+      {
+        MP4DisposeHandle(sampleH);
+        return err;
+      }
+    }
+
+    MP4DisposeHandle(sampleH);
+  }
+
+  return MP4NoErr;
+}
+
+} // namespace t35

--- a/IsoLib/t35_tool/injection/BitstreamStrategy.hpp
+++ b/IsoLib/t35_tool/injection/BitstreamStrategy.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "InjectionStrategy.hpp"
+
+namespace t35 {
+
+/**
+ * @brief Injection strategy that inserts T.35 metadata directly into the video bitstream.
+ *
+ * For AV1: Inserts metadata OBU of type T35.
+ * For HEVC: Inserts SEI NALU (nal_unit_type=39, payload_type=4).
+ *
+ * This strategy modifies the video samples in place using the new MP4UpdateMediaSample API.
+ */
+class BitstreamStrategy : public InjectionStrategy {
+public:
+    BitstreamStrategy() = default;
+    ~BitstreamStrategy() override = default;
+
+    std::string getName() const override { return "bitstream"; }
+
+    std::string getDescription() const override {
+        return "Inject T.35 metadata directly into the video bitstream (AV1/HEVC)";
+    }
+
+    bool isApplicable(const MetadataMap& items,
+                     const InjectionConfig& config,
+                     std::string& reason) const override;
+
+    MP4Err inject(const InjectionConfig& config,
+                  const MetadataMap& items,
+                  const T35Prefix& prefix) override;
+};
+
+} // namespace t35

--- a/IsoLib/t35_tool/injection/InjectionStrategy.cpp
+++ b/IsoLib/t35_tool/injection/InjectionStrategy.cpp
@@ -2,6 +2,7 @@
 #include "MebxMe4cStrategy.hpp"
 #include "DedicatedIt35Strategy.hpp"
 #include "SampleGroupStrategy.hpp"
+#include "BitstreamStrategy.hpp"
 #include "../common/Logger.hpp"
 
 namespace t35
@@ -22,6 +23,10 @@ std::unique_ptr<InjectionStrategy> createInjectionStrategy(const std::string &st
   else if(strategyName == "sample-group")
   {
     return std::make_unique<SampleGroupStrategy>();
+  }
+  else if(strategyName == "bitstream")
+  {
+    return std::make_unique<BitstreamStrategy>();
   }
   else if(strategyName == "sei")
   {

--- a/IsoLib/t35_tool/t35_tool.cpp
+++ b/IsoLib/t35_tool/t35_tool.cpp
@@ -52,6 +52,7 @@ void printAvailableOptions()
   std::cout << "  mebx-me4c                - MEBX track with me4c namespace (default)\n";
   std::cout << "  dedicated-it35           - Dedicated metadata track\n";
   std::cout << "  sample-group             - Sample group\n";
+  std::cout << "  bitstream                - Inject into video bitstream (AV1/HEVC)\n";
   std::cout << "\n";
   std::cout << "Available extraction methods:\n";
   std::cout << "  auto                     - Auto-detect (default)\n";

--- a/TestData/t35_tool/test_all_modes.sh
+++ b/TestData/t35_tool/test_all_modes.sh
@@ -74,6 +74,8 @@ INJECTION_MODES=(
     "mebx-me4c"
     "dedicated-it35"
     "sample-group"
+    # Won't work with the test video 01_simple.mp4 because it's neither HEVC nor AV1
+    # "bitstream"
 )
 
 # Results tracking (simple arrays instead of associative array)


### PR DESCRIPTION
This method stores metadata in T35 metadata OBUs for AV1, or SEI NALUs for HEVC.